### PR TITLE
New script for tracing DToL status in Ensembl

### DIFF
--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -2,21 +2,23 @@
 
 A script to check the status of Ensembl annotation on the DToL assemblies. It can also produce a list of databases that need to be added to the DToL projects page, https://projects.ensembl.org/darwin-tree-of-life/.
 
+
 ## To run
 
 **python3 dtol_tracking.py -h**
 
-usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]
+usage: `dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]`
 
 Track status of DToL assemblies in Ensembl.
 
 optional arguments:
-> -h, --help	show this help message and exit
-
-> --summary SUMMARY      Provide a summary of the status of DToL assemblies in Ensembl
-
-> --in_progress IN_PROGRESS      Provide a summary of the status of DToL assemblies in Ensembl
-
-> --unannotated UNANNOTATED      Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
-
-> --projects_missing PROJECTS_MISSING    Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org
+```
+  -h, --help            show this help message and exit
+  --summary SUMMARY     Provide a summary of the status of DToL assemblies in Ensembl
+  --in_progress IN_PROGRESS
+                        Provide a summary of the status of DToL assemblies in Ensembl
+  --unannotated UNANNOTATED
+                        Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
+  --projects_missing PROJECTS_MISSING
+                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org
+```

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -5,13 +5,18 @@ A script to check the status of Ensembl annotation on the DToL assemblies. It ca
 ## To run
 
 **python3 dtol_tracking.py -h**
-\usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]
+
+usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]
 
 Track status of DToL assemblies in Ensembl.
 
 optional arguments:
 > -h, --help	show this help message and exit
+
 > --summary SUMMARY      Provide a summary of the status of DToL assemblies in Ensembl
+
 > --in_progress IN_PROGRESS      Provide a summary of the status of DToL assemblies in Ensembl
+
 > --unannotated UNANNOTATED      Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
+
 > --projects_missing PROJECTS_MISSING    Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -20,5 +20,6 @@ optional arguments:
   --unannotated UNANNOTATED
                         Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
   --projects_missing PROJECTS_MISSING
-                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org
+                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies
+                        that have been release on rapid.ensembl.org
 ```

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -1,0 +1,22 @@
+# DToL Tracking script
+
+A script to check the status of Ensembl annotation on the DToL assemblies. It can also produce a list of databases that need to be added to the DToL projects page, https://projects.ensembl.org/darwin-tree-of-life/.
+
+## To run
+
+**python3 dtol_tracking.py -h**
+usage: dtol_tracking.py [-h] [-summary SUMMARY] [-in_progress IN_PROGRESS] [-unannotated UNANNOTATED] [-projects_missing PROJECTS_MISSING]
+
+Track status of DToL assemblies in Ensembl.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -summary SUMMARY      Provide a summary of the status of DToL assemblies in Ensembl
+  -in_progress IN_PROGRESS
+                        Provide a summary of the status of DToL assemblies in Ensembl
+  -unannotated UNANNOTATED
+                        Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
+  -projects_missing PROJECTS_MISSING
+                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org
+
+

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -5,18 +5,18 @@ A script to check the status of Ensembl annotation on the DToL assemblies. It ca
 ## To run
 
 **python3 dtol_tracking.py -h**
-usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]\
+usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]
 
-Track status of DToL assemblies in Ensembl.\
+Track status of DToL assemblies in Ensembl.
 
-optional arguments:\
-  > -h, --help
-  >>show this help message and exit\
-  > --summary SUMMARY\
-  >> Provide a summary of the status of DToL assemblies in Ensembl\
-  > --in_progress IN_PROGRESS\
-  >> Provide a summary of the status of DToL assemblies in Ensembl\
-  > --unannotated UNANNOTATED\
-  >> Provide a list of GCAs for the DToL assemblies that have yet to be annotated.\
-  > --projects_missing PROJECTS_MISSING\
-  >> Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org\
+optional arguments:
+&nbsp;&nbsp;-h, --help
+&nbsp;&nbsp;&nbsp;&nbsp;show this help message and exit
+&nbsp;&nbsp;--summary SUMMARY
+&nbsp;&nbsp;&nbsp;&nbsp;Provide a summary of the status of DToL assemblies in Ensembl
+&nbsp;&nbsp;--in_progress IN_PROGRESS
+&nbsp;&nbsp;&nbsp;&nbsp;Provide a summary of the status of DToL assemblies in Ensembl
+&nbsp;&nbsp;--unannotated UNANNOTATED
+&nbsp;&nbsp;&nbsp;&nbsp;Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
+&nbsp;&nbsp;--projects_missing PROJECTS_MISSING
+&nbsp;&nbsp;&nbsp;&nbsp;Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -5,16 +5,18 @@ A script to check the status of Ensembl annotation on the DToL assemblies. It ca
 ## To run
 
 **python3 dtol_tracking.py -h**
-usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]\\
+usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]\
 
-Track status of DToL assemblies in Ensembl.\\
+Track status of DToL assemblies in Ensembl.\
 
 optional arguments:\
-  -h, --help            show this help message and exit\
-  --summary SUMMARY     Provide a summary of the status of DToL assemblies in Ensembl\
-  --in_progress IN_PROGRESS\
-                        Provide a summary of the status of DToL assemblies in Ensembl\
-  --unannotated UNANNOTATED\
-                        Provide a list of GCAs for the DToL assemblies that have yet to be annotated.\
-  --projects_missing PROJECTS_MISSING\
-                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org\
+  > -h, --help
+  >>show this help message and exit\
+  > --summary SUMMARY\
+  >> Provide a summary of the status of DToL assemblies in Ensembl\
+  > --in_progress IN_PROGRESS\
+  >> Provide a summary of the status of DToL assemblies in Ensembl\
+  > --unannotated UNANNOTATED\
+  >> Provide a list of GCAs for the DToL assemblies that have yet to be annotated.\
+  > --projects_missing PROJECTS_MISSING\
+  >> Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org\

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -5,18 +5,16 @@ A script to check the status of Ensembl annotation on the DToL assemblies. It ca
 ## To run
 
 **python3 dtol_tracking.py -h**
-usage: dtol_tracking.py [-h] [-summary SUMMARY] [-in_progress IN_PROGRESS] [-unannotated UNANNOTATED] [-projects_missing PROJECTS_MISSING]
+usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]\\
 
-Track status of DToL assemblies in Ensembl.
+Track status of DToL assemblies in Ensembl.\\
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -summary SUMMARY      Provide a summary of the status of DToL assemblies in Ensembl
-  -in_progress IN_PROGRESS
-                        Provide a summary of the status of DToL assemblies in Ensembl
-  -unannotated UNANNOTATED
-                        Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
-  -projects_missing PROJECTS_MISSING
-                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org
-
-
+optional arguments:\
+  -h, --help            show this help message and exit\
+  --summary SUMMARY     Provide a summary of the status of DToL assemblies in Ensembl\
+  --in_progress IN_PROGRESS\
+                        Provide a summary of the status of DToL assemblies in Ensembl\
+  --unannotated UNANNOTATED\
+                        Provide a list of GCAs for the DToL assemblies that have yet to be annotated.\
+  --projects_missing PROJECTS_MISSING\
+                        Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org\

--- a/scripts/dtol_tracking/README.md
+++ b/scripts/dtol_tracking/README.md
@@ -5,18 +5,13 @@ A script to check the status of Ensembl annotation on the DToL assemblies. It ca
 ## To run
 
 **python3 dtol_tracking.py -h**
-usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]
+\usage: dtol_tracking.py [-h] [--summary SUMMARY] [--in_progress IN_PROGRESS] [--unannotated UNANNOTATED] [--projects_missing PROJECTS_MISSING]
 
 Track status of DToL assemblies in Ensembl.
 
 optional arguments:
-&nbsp;&nbsp;-h, --help
-&nbsp;&nbsp;&nbsp;&nbsp;show this help message and exit
-&nbsp;&nbsp;--summary SUMMARY
-&nbsp;&nbsp;&nbsp;&nbsp;Provide a summary of the status of DToL assemblies in Ensembl
-&nbsp;&nbsp;--in_progress IN_PROGRESS
-&nbsp;&nbsp;&nbsp;&nbsp;Provide a summary of the status of DToL assemblies in Ensembl
-&nbsp;&nbsp;--unannotated UNANNOTATED
-&nbsp;&nbsp;&nbsp;&nbsp;Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
-&nbsp;&nbsp;--projects_missing PROJECTS_MISSING
-&nbsp;&nbsp;&nbsp;&nbsp;Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org
+> -h, --help	show this help message and exit
+> --summary SUMMARY      Provide a summary of the status of DToL assemblies in Ensembl
+> --in_progress IN_PROGRESS      Provide a summary of the status of DToL assemblies in Ensembl
+> --unannotated UNANNOTATED      Provide a list of GCAs for the DToL assemblies that have yet to be annotated.
+> --projects_missing PROJECTS_MISSING    Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org

--- a/scripts/dtol_tracking/dtol_tracking.py
+++ b/scripts/dtol_tracking/dtol_tracking.py
@@ -1,0 +1,234 @@
+import os.path, sys, getopt
+import argparse
+import requests
+import pymysql
+
+
+class text:
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    END = "\033[0m"
+
+
+def mysql_fetch_data(query, database, host, port, user, password, multi):
+    try:
+        conn = pymysql.connect(
+            host=host, user=user, passwd=password, port=port, database=database.strip()
+        )
+        cursor = conn.cursor()
+        info = []
+        if multi:
+            for stmt in query.split(";"):
+                if stmt.strip():
+                    cursor.execute(stmt)
+                    info.append(cursor.fetchall())
+        else:
+            cursor.execute(query)
+            info = cursor.fetchall()
+
+    except mysql.connector.Error as err:
+        if err.errno == errorcode.ER_ACCESS_DENIED_ERROR:
+            print("Something is wrong with your user name or password")
+        elif err.errno == errorcode.ER_BAD_DB_ERROR:
+            print("Database does not exist on the server")
+        else:
+            print(err)
+
+    cursor.close()
+    conn.close()
+    return info
+
+
+def check_site(gca_list, site):
+    on_list = []
+    not_on_list = []
+    if site == "rapid":
+        species_list_url = "https://rapid.ensembl.org/info/about/species.html"
+        species_list_response = requests.get(species_list_url)
+    elif site == "projects":
+        species_list_url = "https://projects.ensembl.org/darwin-tree-of-life/"
+        species_list_response = requests.get(species_list_url)
+    for gca in gca_list:
+        if gca in species_list_response.text:
+            on_list.append(gca)
+        else:
+            not_on_list.append(gca)
+    return (on_list, not_on_list)
+
+
+if __name__ == "__main__":
+
+    # registry db details
+    db_name = "gb_assembly_registry"
+    db_host = "mysql-ens-genebuild-prod-1.ebi.ac.uk"
+    db_port = 4527
+    db_user = "ensro"
+    db_pass = ""
+
+    # rapid meta db details
+    meta_db_name = "ensembl_metadata_qrp"
+    meta_db_host = "mysql-ens-meta-prod-1.ebi.ac.uk"
+    meta_db_port = 4483
+    meta_db_user = "ensro"
+    meta_db_pass = ""
+
+    parser = argparse.ArgumentParser(
+        description="Track status of DToL assemblies in Ensembl."
+    )
+    parser.add_argument(
+        "-summary",
+        help="Provide a summary of the status of DToL assemblies in Ensembl",
+        required=False,
+    )
+    parser.add_argument(
+        "-in_progress",
+        help="Provide a summary of the status of DToL assemblies in Ensembl",
+        required=False,
+    )
+    parser.add_argument(
+        "-unannotated",
+        help="Provide a list of GCAs for the DToL assemblies that have yet to be annotated.",
+        required=False,
+    )
+    parser.add_argument(
+        "-projects_missing",
+        help="Provide a list of the core dbs for the Ensembl annotated DToL assemblies that have been release on rapid.ensembl.org",
+        required=False,
+    )
+
+    args = parser.parse_args()
+    summary = args.summary
+    in_progress = args.in_progress
+    unannotated = args.unannotated
+    projects_missing = args.projects_missing
+
+    dtol_count_query = 'SELECT count(*) FROM assembly JOIN meta USING(assembly_id) WHERE meta.assembly_group="dtol";SELECT count(*) FROM assembly JOIN meta USING(assembly_id) WHERE meta.assembly_group="dtol" AND meta.assembly_name LIKE "%alternate%";SELECT count(*) FROM assembly JOIN meta USING(assembly_id) WHERE meta.assembly_group="dtol" AND assembly.annotated_status="ensembl";SELECT count(*) FROM assembly JOIN meta USING(assembly_id) WHERE meta.assembly_group="dtol" AND assembly.annotated_status="ensembl" AND meta.assembly_name LIKE "%alternate%";'
+    dtol_count_fetch = mysql_fetch_data(
+        dtol_count_query,
+        db_name,
+        db_host,
+        db_port,
+        db_user,
+        db_pass,
+        1,
+    )
+    dtol_count = dtol_count_fetch[0][0][0]
+    dtol_alternates = dtol_count_fetch[1][0][0]
+    dtol_annotated = dtol_count_fetch[2][0][0]
+    dtol_annotated_alternates = dtol_count_fetch[3][0][0]
+
+    dtol_annotated_gcas_query = 'SELECT assembly.chain, assembly.version FROM assembly JOIN meta USING (assembly_id) WHERE meta.assembly_group="dtol" AND assembly.annotated_status="ensembl";'
+    dtol_annotated_gcas_return = mysql_fetch_data(
+        dtol_annotated_gcas_query,
+        db_name,
+        db_host,
+        db_port,
+        db_user,
+        db_pass,
+        0,
+    )
+    dtol_annotated_gcas = []
+    for tuple in dtol_annotated_gcas_return:
+        dtol_annotated_gcas.append(str(tuple[0]) + "." + str(tuple[1]))
+
+    if summary:
+        print(
+            text.BOLD
+            + "\nNumber of DToL assemblies in public archives: "
+            + str(dtol_count)
+            + text.END
+            + " (of which are alternate assemblies: "
+            + str(dtol_alternates)
+            + ")\n"
+            + text.BOLD
+            + "Number of Ensembl annotated DToL assemblies: "
+            + str(dtol_annotated)
+            + ""
+            + text.END
+            + " (of which are alternate assemblies: "
+            + str(dtol_annotated_alternates)
+            + ")\n"
+        )
+
+    if in_progress:
+        dtol_in_progress_gcas_query = 'SELECT assembly.chain, assembly.version FROM assembly JOIN meta USING (assembly_id) JOIN genebuild_status USING (assembly_id) WHERE meta.assembly_group="dtol" AND genebuild_status.progress_status="in_progress";'
+        dtol_in_progress_gcas_return = mysql_fetch_data(
+            dtol_in_progress_gcas_query,
+            db_name,
+            db_host,
+            db_port,
+            db_user,
+            db_pass,
+            0,
+        )
+        dtol_in_progress_gcas = []
+        for tuple in dtol_in_progress_gcas_return:
+            dtol_in_progress_gcas.append(str(tuple[0]) + "." + str(tuple[1]))
+
+        print(
+            text.BOLD
+            + "Annotations for "
+            + str(len(dtol_in_progress_gcas))
+            + " DToL assemblies are currently in progress.\n"
+            + text.END
+            + "Assembly accessions:\n"
+        )
+        for gca in dtol_in_progress_gcas:
+            print(gca)
+
+    if unannotated:
+        dtol_unannotated_gcas_query = 'SELECT assembly.chain, assembly.version FROM assembly JOIN meta USING (assembly_id) WHERE meta.assembly_group="dtol" AND assembly.annotated_status="unannotated";'
+        dtol_unannotated_gcas_return = mysql_fetch_data(
+            dtol_unannotated_gcas_query,
+            db_name,
+            db_host,
+            db_port,
+            db_user,
+            db_pass,
+            0,
+        )
+        dtol_unannotated_gcas = []
+        for tuple in dtol_unannotated_gcas_return:
+            dtol_unannotated_gcas.append(str(tuple[0]) + "." + str(tuple[1]))
+        print(
+            text.BOLD
+            + str(len(dtol_unannotated_gcas))
+            + " DToL assemblies are yet to be annotated.\n"
+            + text.END
+            + "Assembly accessions:\n"
+        )
+        for gca in dtol_unannotated_gcas:
+            print(gca)
+
+    if projects_missing:
+        projects_released, projects_unreleased = check_site(
+            dtol_annotated_gcas, "projects"
+        )
+        unreleased_dbs = []
+        for gca in projects_unreleased:
+            unreleased_gca_query = (
+                'SELECT dbname FROM assembly JOIN genome USING (assembly_id) JOIN genome_database USING (genome_id) WHERE genome.data_release_id=(SELECT MAX(data_release_id) FROM genome) AND assembly.assembly_accession="'
+                + gca
+                + '";'
+            )
+            unreleased_gca_return = mysql_fetch_data(
+                unreleased_gca_query,
+                meta_db_name,
+                meta_db_host,
+                meta_db_port,
+                meta_db_user,
+                meta_db_pass,
+                0,
+            )
+
+            unreleased_dbs.append(unreleased_gca_return[0][0])
+
+        print(
+            text.BOLD
+            + str(len(unreleased_dbs))
+            + " DToL assemblies have been annotated but do not appear on https://projects.ensembl.org/darwin-tree-of-life/.\n"
+            + text.END
+            + "Core databases:\n"
+        )
+        for db in unreleased_dbs:
+            print(db)

--- a/scripts/dtol_tracking/poetry.lock
+++ b/scripts/dtol_tracking/poetry.lock
@@ -1,0 +1,213 @@
+[[package]]
+name = "certifi"
+version = "2021.10.8"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "2.0.12"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.5.0"
+
+[package.extras]
+unicode_backport = ["unicodedata2"]
+
+[[package]]
+name = "idna"
+version = "3.3"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "numpy"
+version = "1.22.3"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
+name = "pandas"
+version = "1.4.2"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+numpy = [
+    {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.19.2", markers = "platform_machine == \"aarch64\" and python_version < \"3.10\""},
+    {version = ">=1.20.0", markers = "platform_machine == \"arm64\" and python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
+]
+python-dateutil = ">=2.8.1"
+pytz = ">=2020.1"
+
+[package.extras]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+
+[[package]]
+name = "pymysql"
+version = "1.0.2"
+description = "Pure Python MySQL Driver"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+ed25519 = ["PyNaCl (>=1.4.0)"]
+rsa = ["cryptography"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "pytz"
+version = "2022.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "requests"
+version = "2.27.1"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = {version = ">=2.0.0,<2.1.0", markers = "python_version >= \"3\""}
+idna = {version = ">=2.5,<4", markers = "python_version >= \"3\""}
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.8"
+content-hash = "a8b8e5894a43b02caa68f8e2a06f973c11ca2e77e4bd4e051ece80a29c25df5f"
+
+[metadata.files]
+certifi = [
+    {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
+    {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+]
+idna = [
+    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
+    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
+]
+numpy = [
+    {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
+    {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
+    {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
+    {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
+    {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:568dfd16224abddafb1cbcce2ff14f522abe037268514dd7e42c6776a1c3f8e5"},
+    {file = "numpy-1.22.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ca688e1b9b95d80250bca34b11a05e389b1420d00e87a0d12dc45f131f704a1"},
+    {file = "numpy-1.22.3-cp38-cp38-win32.whl", hash = "sha256:e7927a589df200c5e23c57970bafbd0cd322459aa7b1ff73b7c2e84d6e3eae62"},
+    {file = "numpy-1.22.3-cp38-cp38-win_amd64.whl", hash = "sha256:07a8c89a04997625236c5ecb7afe35a02af3896c8aa01890a849913a2309c676"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:2c10a93606e0b4b95c9b04b77dc349b398fdfbda382d2a39ba5a822f669a0123"},
+    {file = "numpy-1.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fade0d4f4d292b6f39951b6836d7a3c7ef5b2347f3c420cd9820a1d90d794802"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5bfb1bb598e8229c2d5d48db1860bcf4311337864ea3efdbe1171fb0c5da515d"},
+    {file = "numpy-1.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:97098b95aa4e418529099c26558eeb8486e66bd1e53a6b606d684d0c3616b168"},
+    {file = "numpy-1.22.3-cp39-cp39-win32.whl", hash = "sha256:fdf3c08bce27132395d3c3ba1503cac12e17282358cb4bddc25cc46b0aca07aa"},
+    {file = "numpy-1.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:639b54cdf6aa4f82fe37ebf70401bbb74b8508fddcf4797f9fe59615b8c5813a"},
+    {file = "numpy-1.22.3-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c34ea7e9d13a70bf2ab64a2532fe149a9aced424cd05a2c4ba662fd989e3e45f"},
+    {file = "numpy-1.22.3.zip", hash = "sha256:dbc7601a3b7472d559dc7b933b18b4b66f9aa7452c120e87dfb33d02008c8a18"},
+]
+pandas = [
+    {file = "pandas-1.4.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:be67c782c4f1b1f24c2f16a157e12c2693fd510f8df18e3287c77f33d124ed07"},
+    {file = "pandas-1.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5a206afa84ed20e07603f50d22b5f0db3fb556486d8c2462d8bc364831a4b417"},
+    {file = "pandas-1.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0010771bd9223f7afe5f051eb47c4a49534345dfa144f2f5470b27189a4dd3b5"},
+    {file = "pandas-1.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3228198333dd13c90b6434ddf61aa6d57deaca98cf7b654f4ad68a2db84f8cfe"},
+    {file = "pandas-1.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b79af3a69e5175c6fa7b4e046b21a646c8b74e92c6581a9d825687d92071b51"},
+    {file = "pandas-1.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:5586cc95692564b441f4747c47c8a9746792e87b40a4680a2feb7794defb1ce3"},
+    {file = "pandas-1.4.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:061609334a8182ab500a90fe66d46f6f387de62d3a9cb9aa7e62e3146c712167"},
+    {file = "pandas-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b8134651258bce418cb79c71adeff0a44090c98d955f6953168ba16cc285d9f7"},
+    {file = "pandas-1.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:df82739e00bb6daf4bba4479a40f38c718b598a84654cbd8bb498fd6b0aa8c16"},
+    {file = "pandas-1.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:385c52e85aaa8ea6a4c600a9b2821181a51f8be0aee3af6f2dcb41dafc4fc1d0"},
+    {file = "pandas-1.4.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:295872bf1a09758aba199992c3ecde455f01caf32266d50abc1a073e828a7b9d"},
+    {file = "pandas-1.4.2-cp38-cp38-win32.whl", hash = "sha256:95c1e422ced0199cf4a34385ff124b69412c4bc912011ce895582bee620dfcaa"},
+    {file = "pandas-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:5c54ea4ef3823108cd4ec7fb27ccba4c3a775e0f83e39c5e17f5094cb17748bc"},
+    {file = "pandas-1.4.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c072c7f06b9242c855ed8021ff970c0e8f8b10b35e2640c657d2a541c5950f59"},
+    {file = "pandas-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f549097993744ff8c41b5e8f2f0d3cbfaabe89b4ae32c8c08ead6cc535b80139"},
+    {file = "pandas-1.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ff08a14ef21d94cdf18eef7c569d66f2e24e0bc89350bcd7d243dd804e3b5eb2"},
+    {file = "pandas-1.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c5bf555b6b0075294b73965adaafb39cf71c312e38c5935c93d78f41c19828a"},
+    {file = "pandas-1.4.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51649ef604a945f781105a6d2ecf88db7da0f4868ac5d45c51cb66081c4d9c73"},
+    {file = "pandas-1.4.2-cp39-cp39-win32.whl", hash = "sha256:d0d4f13e4be7ce89d7057a786023c461dd9370040bdb5efa0a7fe76b556867a0"},
+    {file = "pandas-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:09d8be7dd9e1c4c98224c4dfe8abd60d145d934e9fc1f5f411266308ae683e6a"},
+    {file = "pandas-1.4.2.tar.gz", hash = "sha256:92bc1fc585f1463ca827b45535957815b7deb218c549b7c18402c322c7549a12"},
+]
+pymysql = [
+    {file = "PyMySQL-1.0.2-py3-none-any.whl", hash = "sha256:41fc3a0c5013d5f039639442321185532e3e2c8924687abe6537de157d403641"},
+    {file = "PyMySQL-1.0.2.tar.gz", hash = "sha256:816927a350f38d56072aeca5dfb10221fe1dc653745853d30a216637f5d7ad36"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+pytz = [
+    {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
+    {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
+]
+requests = [
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+]

--- a/scripts/dtol_tracking/poetry.lock
+++ b/scripts/dtol_tracking/poetry.lock
@@ -33,14 +33,6 @@ category = "main"
 optional = false
 python-versions = ">=3.8"
 
-[[package]]
-name = "pandas"
-version = "1.4.2"
-description = "Powerful data structures for data analysis, time series, and statistics"
-category = "main"
-optional = false
-python-versions = ">=3.8"
-
 [package.dependencies]
 numpy = [
     {version = ">=1.18.5", markers = "platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\""},

--- a/scripts/dtol_tracking/pyproject.toml
+++ b/scripts/dtol_tracking/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
-name = "scripts"
+name = "DToL tracking script"
 version = "0.1.0"
-description = ""
-authors = ["Your Name <you@example.com>"]
-license = "n"
+description = "Track status of DToL assemblies in Ensembl."
+authors = ["genebuild <ensembl-genebuild@ebi.ac.uk>"]
+license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/scripts/dtol_tracking/pyproject.toml
+++ b/scripts/dtol_tracking/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.poetry]
+name = "scripts"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <you@example.com>"]
+license = "n"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+PyMySQL = "^1.0.2"
+pandas = "^1.4.2"
+requests = "^2.27.1"
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/scripts/dtol_tracking/pyproject.toml
+++ b/scripts/dtol_tracking/pyproject.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [tool.poetry.dependencies]
 python = "^3.8"
 PyMySQL = "^1.0.2"
-pandas = "^1.4.2"
 requests = "^2.27.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
We needed something to quickly give us a list of databases that need to be added to the DToL projects page... so here it is.

It accesses the gb_assembly_registry and ensembl_metadata_qrp databases for info

The script will return:
- a summary of the DToL assemblies in Ensembl <-summary 1>
- a list of the GCAs that are in progress <-in_progress 1> (currently returns 0, none are set to "in progress" in the genebuild_status table in gb_assembly_registry)
- a list of GCAs that have not been annotated yet <-unannotated 1>
- a list of core dbs for assemblies that have been annotated but do not appear on the projects page yet

There is potential to add checks on rapid release too (e.g. what has been annotated and not released)