### PR TITLE
Add column for alternate assemblies for the DToL projects page

### DIFF
--- a/scripts/projects_page/dtol_species.yaml
+++ b/scripts/projects_page/dtol_species.yaml
@@ -11,6 +11,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1
   rapid_link: https://rapid.ensembl.org/Abrostola_tripartita_gca905340225v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/abrostola_tripartita_GCA_905340225.1/abrostola_tripartita_gca905340225v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Abrostola_tripartita_GCA_905340255.1/Info/Index
 
 - species: Acronicta aceris
   image: Lepidoptera.png
@@ -38,6 +39,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1
   rapid_link: https://rapid.ensembl.org/Adalia_bipunctata_gca910592335v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/adalia_bipunctata_GCA_910592335.1/adalia_bipunctata_gca910592335v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Adalia_bipunctata_GCA_910591895.1/Info/Index
 
 - species: Agriopis aurantiaria
   image: Lepidoptera.png
@@ -51,6 +53,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agriopis_aurantiaria/GCA_914767915.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1
   rapid_link: https://rapid.ensembl.org/Agriopis_aurantiaria_gca914767915v1/Info/Index
+  alternate: https://rapid.ensembl.org/Agriopis_aurantiaria_GCA_914767795.1/Info/Index
 
 - species: Agrochola circellaris
   image: Lepidoptera.png
@@ -64,6 +67,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agrochola_circellaris/GCA_914767755.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1
   rapid_link: https://rapid.ensembl.org/Agrochola_circellaris_gca914767755v1/Info/Index
+  alternate: https://rapid.ensembl.org/Agrochola_circellaris_GCA_914767685.1/Info/Index
 
 - species: Agrochola macilenta
   image: Lepidoptera.png
@@ -77,6 +81,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agrochola_macilenta/GCA_916701695.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1
   rapid_link: https://rapid.ensembl.org/Agrochola_macilenta_gca916701695v1/Info/Index
+  alternate: https://rapid.ensembl.org/Agrochola_macilenta_GCA_916701705.1/Info/Index
 
 - species: Amphipyra berbera
   image: Lepidoptera.png
@@ -91,6 +96,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1
   rapid_link: https://rapid.ensembl.org/Amphipyra_berbera_gca910594945v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_berbera_GCA_910594945.1/amphipyra_berbera_gca910594945v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Amphipyra_berbera_GCA_910595045.1/Info/Index
 
 - species: Amphipyra berbera
   image: Lepidoptera.png
@@ -119,6 +125,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1
   rapid_link: https://rapid.ensembl.org/Amphipyra_tragopoginis_gca905220435v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_tragopoginis_GCA_905220435.1/amphipyra_tragopoginis_gca905220435v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Amphipyra_tragopoginis_GCA_905220425.1/Info/Index
 
 - species: Ancistrocerus nigricornis
   image: Arthropods.png
@@ -133,6 +140,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1
   rapid_link: https://rapid.ensembl.org/Ancistrocerus_nigricornis_gca916049575v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ancistrocerus_nigricornis_GCA_916049575.1/ancistrocerus_nigricornis_gca916049575v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ancistrocerus_nigricornis_GCA_916050135.1/Info/Index
 
 - species: Andrena dorsata
   image: Arthropods.png
@@ -146,6 +154,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_dorsata/GCA_929108735.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1
   rapid_link: https://rapid.ensembl.org/Andrena_dorsata_gca929108735v1/Info/Index
+  alternate: https://rapid.ensembl.org/Andrena_dorsata_GCA_929114765.1/Info/Index
 
 - species: Andrena haemorrhoa
   image: Arthropods.png
@@ -160,6 +169,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1
   rapid_link: https://rapid.ensembl.org/Andrena_haemorrhoa_gca910592295v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/andrena_haemorrhoa_GCA_910592295.1/andrena_haemorrhoa_gca910592295v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Andrena_haemorrhoa_GCA_910592125.1/Info/Index
 
 - species: Andrena minutula
   image: Arthropods.png
@@ -173,6 +183,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_minutula/GCA_929113495.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1
   rapid_link: https://rapid.ensembl.org/Andrena_minutula_gca929113495v1/Info/Index
+  alternate: https://rapid.ensembl.org/Andrena_minutula_GCA_929113085.1/Info/Index
 
 - species: Anoplius nigerrimus
   image: Arthropods.png
@@ -186,6 +197,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anoplius_nigerrimus/GCA_914767735.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1
   rapid_link: https://rapid.ensembl.org/Anoplius_nigerrimus_gca914767735v1/Info/Index
+  alternate: https://rapid.ensembl.org/Anoplius_nigerrimus_GCA_914767785.1/Info/Index
 
 - species: Anthocharis cardamines
   image: Lepidoptera.png
@@ -199,6 +211,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anthocharis_cardamines/GCA_905404175.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1
   rapid_link: https://rapid.ensembl.org/Anthocharis_cardamines_gca905404175v1/Info/Index
+  alternate: https://rapid.ensembl.org/Anthocharis_cardamines_GCA_905404305.1/Info/Index
 
 - species: Apamea monoglypha
   image: Lepidoptera.png
@@ -212,6 +225,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/apamea_monoglypha/GCA_911387795.2.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2
   rapid_link: https://rapid.ensembl.org/Apamea_monoglypha_gca911387795v2/Info/Index
+  alternate: https://rapid.ensembl.org/Apamea_monoglypha_GCA_911387735.2/Info/Index
 
 - species: Aporia crataegi
   image: Lepidoptera.png
@@ -226,6 +240,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1
   rapid_link: https://rapid.ensembl.org/Aporia_crataegi_gca912999735v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/aporia_crataegi_GCA_912999735.1/aporia_crataegi_gca912999735v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Aporia_crataegi_GCA_912999795.1/Info/Index
 
 - species: Apotomis turbidana
   image: Lepidoptera.png
@@ -332,6 +347,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/autographa_pulchrina/GCA_905475315.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1
   rapid_link: https://rapid.ensembl.org/Autographa_pulchrina_gca905475315v1/Info/Index
+  alternate: https://rapid.ensembl.org/Autographa_pulchrina_GCA_905475435.1/Info/Index
 
 - species: Bellardia pandia
   image: Arthropods.png
@@ -357,6 +373,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bembecia_ichneumoniformis/GCA_910589475.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1
   rapid_link: https://rapid.ensembl.org/Bembecia_ichneumoniformis_gca910589475v1/Info/Index
+  alternate: https://rapid.ensembl.org/Bembecia_ichneumoniformis_GCA_910589565.1/Info/Index
 
 - species: Biston betularia
   image: Lepidoptera.png
@@ -370,6 +387,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/biston_betularia/GCA_905404145.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1
   rapid_link: https://rapid.ensembl.org/Biston_betularia_gca905404145v1/Info/Index
+  alternate: https://rapid.ensembl.org/Biston_betularia_GCA_905404215.1/Info/Index
 
 - species: Biston betularia
   image: Lepidoptera.png
@@ -398,6 +416,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1
   rapid_link: https://rapid.ensembl.org/Blastobasis_adustella_gca907269095v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/blastobasis_adustella_GCA_907269095.1/blastobasis_adustella_gca907269095v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Blastobasis_adustella_GCA_907269055.1/Info/Index
 
 - species: Blastobasis lacticolella
   image: Lepidoptera.png
@@ -412,6 +431,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1
   rapid_link: https://rapid.ensembl.org/Blastobasis_lacticolella_gca905147135v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/blastobasis_lacticolella_GCA_905147135.1/blastobasis_lacticolella_gca905147135v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Blastobasis_lacticolella_GCA_905147205.1/Info/Index
 
 - species: Boloria selene
   image: Lepidoptera.png
@@ -494,6 +514,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1
   rapid_link: https://rapid.ensembl.org/Bombus_pascuorum_gca905332965v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_pascuorum_GCA_905332965.1/bombus_pascuorum_gca905332965v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Bombus_pascuorum_GCA_905332995.1/Info/Index
 
 - species: Bombus pratorum
   image: Arthropods.png
@@ -507,6 +528,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_pratorum/GCA_930367275.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1
   rapid_link: https://rapid.ensembl.org/Bombus_pratorum_gca930367275v1/Info/Index
+  alternate: https://rapid.ensembl.org/Bombus_pratorum_GCA_930367225.1/Info/Index
 
 - species: Bombus sylvestris
   image: Arthropods.png
@@ -561,6 +583,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_terrestris/GCA_910591885.2.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2
   rapid_link: https://rapid.ensembl.org/Bombus_terrestris_gca910591885v2/Info/Index
+  alternate: https://rapid.ensembl.org/Bombus_terrestris_GCA_910592195.2/Info/Index
 
 - species: Campaea margaritaria
   image: Lepidoptera.png
@@ -574,6 +597,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/campaea_margaritaria/GCA_912999815.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1
   rapid_link: https://rapid.ensembl.org/Campaea_margaritaria_gca912999815v1/Info/Index
+  alternate: https://rapid.ensembl.org/Campaea_margaritaria_GCA_912999775.1/Info/Index
 
 - species: Canis lupus
   image: Mammals.png
@@ -600,6 +624,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cantharis_rustica/GCA_911387805.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1
   rapid_link: https://rapid.ensembl.org/Cantharis_rustica_gca911387805v1/Info/Index
+  alternate: https://rapid.ensembl.org/Cantharis_rustica_GCA_911387815.1/Info/Index
 
 - species: Carcina quercana
   image: Lepidoptera.png
@@ -626,6 +651,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/celastrina_argiolus/GCA_905187575.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1
   rapid_link: https://rapid.ensembl.org/Celastrina_argiolus_gca905187575v1/Info/Index
+  alternate: https://rapid.ensembl.org/Celastrina_argiolus_GCA_905147145.1/Info/Index
 
 - species: Cerceris rybyensis
   image: Arthropods.png
@@ -653,6 +679,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cheilosia_vulpina/GCA_916610125.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1
   rapid_link: https://rapid.ensembl.org/Cheilosia_vulpina_gca916610125v1/Info/Index
+  alternate: https://rapid.ensembl.org/Cheilosia_vulpina_GCA_916610195.1/Info/Index
 
 - species: Chrysoteuchia culmella
   image: Lepidoptera.png
@@ -666,6 +693,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chrysoteuchia_culmella/GCA_910589605.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1
   rapid_link: https://rapid.ensembl.org/Chrysoteuchia_culmella_gca910589605v1/Info/Index
+  alternate: https://rapid.ensembl.org/Chrysoteuchia_culmella_GCA_910589405.1/Info/Index
 
 - species: Chrysotoxum bicinctum
   image: Arthropods.png
@@ -680,6 +708,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1
   rapid_link: https://rapid.ensembl.org/Chrysotoxum_bicinctum_gca911387755v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/chrysotoxum_bicinctum_GCA_911387755.1/chrysotoxum_bicinctum_gca911387755v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Chrysotoxum_bicinctum_GCA_911387745.1/Info/Index
 
 - species: Clostera curtula
   image: Lepidoptera.png
@@ -694,6 +723,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1
   rapid_link: https://rapid.ensembl.org/Clostera_curtula_gca905475355v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/clostera_curtula_GCA_905475355.1/clostera_curtula_gca905475355v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Clostera_curtula_GCA_905475325.1/Info/Index
 
 - species: Clostera curtula
   image: Lepidoptera.png
@@ -722,6 +752,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1
   rapid_link: https://rapid.ensembl.org/Coccinella_septempunctata_gca907165205v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/coccinella_septempunctata_GCA_907165205.1/coccinella_septempunctata_gca907165205v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Coccinella_septempunctata_GCA_907165185.1/Info/Index
 
 - species: Colias croceus
   image: Lepidoptera.png
@@ -735,6 +766,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/colias_croceus/GCA_905220415.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1
   rapid_link: https://rapid.ensembl.org/Colias_croceus_gca905220415v1/Info/Index
+  alternate: https://rapid.ensembl.org/Colias_croceus_GCA_905220445.1/Info/Index
 
 - species: Coremacera marginata
   image: Arthropods.png
@@ -749,6 +781,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1
   rapid_link: https://rapid.ensembl.org/Coremacera_marginata_gca914767935v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/coremacera_marginata_GCA_914767935.1/coremacera_marginata_gca914767935v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Coremacera_marginata_GCA_914767655.1/Info/Index
 
 - species: Cosmia trapezina
   image: Lepidoptera.png
@@ -776,6 +809,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1
   rapid_link: https://rapid.ensembl.org/Craniophora_ligustri_gca905163465v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/craniophora_ligustri_GCA_905163465.1/craniophora_ligustri_gca905163465v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Craniophora_ligustri_GCA_905163585.1/Info/Index
 
 - species: Criorhina berberina
   image: Arthropods.png
@@ -802,6 +836,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/crocallis_elinguaria/GCA_907269065.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1
   rapid_link: https://rapid.ensembl.org/Crocallis_elinguaria_gca907269065v1/Info/Index
+  alternate: https://rapid.ensembl.org/Crocallis_elinguaria_GCA_907269135.1/Info/Index
 
 - species: Cyaniris semiargus
   image: Lepidoptera.png
@@ -815,6 +850,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyaniris_semiargus/GCA_905187585.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1
   rapid_link: https://rapid.ensembl.org/Cyaniris_semiargus_gca905187585v1/Info/Index
+  alternate: https://rapid.ensembl.org/Cyaniris_semiargus_GCA_905147265.1/Info/Index
 
 - species: Cydia splendana
   image: Lepidoptera.png
@@ -829,6 +865,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1
   rapid_link: https://rapid.ensembl.org/Cydia_splendana_gca910591565v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/cydia_splendana_GCA_910591565.1/cydia_splendana_gca910591565v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Cydia_splendana_GCA_910591525.1/Info/Index
 
 - species: Deilephila porcellus
   image: Lepidoptera.png
@@ -881,6 +918,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dryobotodes_eremita/GCA_917490735.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1
   rapid_link: https://rapid.ensembl.org/Dryobotodes_eremita_gca917490735v1/Info/Index
+  alternate: https://rapid.ensembl.org/Dryobotodes_eremita_GCA_917490515.1/Info/Index
 
 - species: Ectemnius continuus
   image: Arthropods.png
@@ -895,6 +933,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1
   rapid_link: https://rapid.ensembl.org/Ectemnius_continuus_gca910591665v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ectemnius_continuus_GCA_910591665.1/ectemnius_continuus_gca910591665v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ectemnius_continuus_GCA_910591485.1/Info/Index
 
 - species: Ectemnius lituratus
   image: Arthropods.png
@@ -935,6 +974,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eilema_depressum/GCA_914767945.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1
   rapid_link: https://rapid.ensembl.org/Eilema_depressum_gca914767945v1/Info/Index
+  alternate: https://rapid.ensembl.org/Eilema_depressum_GCA_914767765.1/Info/Index
 
 - species: Eilema sororculum
   image: Lepidoptera.png
@@ -948,6 +988,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eilema_sororculum/GCA_914829495.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1
   rapid_link: https://rapid.ensembl.org/Eilema_sororculum_gca914829495v1/Info/Index
+  alternate: https://rapid.ensembl.org/Eilema_sororculum_GCA_914829255.1/Info/Index
 
 - species: Emmelina monodactyla
   image: Lepidoptera.png
@@ -961,6 +1002,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/emmelina_monodactyla/GCA_916618145.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1
   rapid_link: https://rapid.ensembl.org/Emmelina_monodactyla_gca916618145v1/Info/Index
+  alternate: https://rapid.ensembl.org/Emmelina_monodactyla_GCA_916618085.1/Info/Index
 
 - species: Endotricha flammealis
   image: Lepidoptera.png
@@ -988,6 +1030,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1
   rapid_link: https://rapid.ensembl.org/Ennomos_fuscantarius_gca905220475v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_fuscantarius_GCA_905220475.1/ennomos_fuscantarius_gca905220475v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ennomos_fuscantarius_GCA_905220485.1/Info/Index
 
 - species: Ennomos fuscantarius
   image: Lepidoptera.png
@@ -1016,6 +1059,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1
   rapid_link: https://rapid.ensembl.org/Ennomos_quercinarius_gca910589525v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_quercinarius_GCA_910589525.1/ennomos_quercinarius_gca910589525v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ennomos_quercinarius_GCA_910589225.1/Info/Index
 
 - species: Erannis defoliaria
   image: Lepidoptera.png
@@ -1029,6 +1073,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erannis_defoliaria/GCA_905404285.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1
   rapid_link: https://rapid.ensembl.org/Erannis_defoliaria_gca905404285v1/Info/Index
+  alternate: https://rapid.ensembl.org/Erannis_defoliaria_GCA_905404195.1/Info/Index
 
 - species: Erebia ligea
   image: Lepidoptera.png
@@ -1042,6 +1087,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erebia_ligea/GCA_917051295.2.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2
   rapid_link: https://rapid.ensembl.org/Erebia_ligea_gca917051295v2/Info/Index
+  alternate: https://rapid.ensembl.org/Erebia_ligea_GCA_917050995.2/Info/Index
 
 - species: Eristalis arbustorum
   image: Arthropods.png
@@ -1056,6 +1102,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1
   rapid_link: https://rapid.ensembl.org/Eristalis_arbustorum_gca916610145v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_arbustorum_GCA_916610145.1/eristalis_arbustorum_gca916610145v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Eristalis_arbustorum_GCA_916610155.1/Info/Index
 
 - species: Eristalis pertinax
   image: Arthropods.png
@@ -1070,6 +1117,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1
   rapid_link: https://rapid.ensembl.org/Eristalis_pertinax_gca907269125v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_pertinax_GCA_907269125.1/eristalis_pertinax_gca907269125v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Eristalis_pertinax_GCA_907269085.1/Info/Index
 
 - species: Eristalis tenax
   image: Arthropods.png
@@ -1084,6 +1132,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1
   rapid_link: https://rapid.ensembl.org/Eristalis_tenax_gca905231855v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_tenax_GCA_905231855.1/eristalis_tenax_gca905231855v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Eristalis_tenax_GCA_905231845.1/Info/Index
 
 - species: Eristalis tenax
   image: Arthropods.png
@@ -1110,6 +1159,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erynnis_tages/GCA_905147235.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1
   rapid_link: https://rapid.ensembl.org/Erynnis_tages_gca905147235v1/Info/Index
+  alternate: https://rapid.ensembl.org/Erynnis_tages_GCA_905147245.1/Info/Index
 
 - species: Eulithis prunata
   image: Lepidoptera.png
@@ -1137,6 +1187,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1
   rapid_link: https://rapid.ensembl.org/Eupeodes_latifasciatus_gca920104205v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eupeodes_latifasciatus_GCA_920104205.1/eupeodes_latifasciatus_gca920104205v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Eupeodes_latifasciatus_GCA_920104105.1/Info/Index
 
 - species: Euproctis similis
   image: Lepidoptera.png
@@ -1178,6 +1229,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eupsilia_transversa/GCA_914767815.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1
   rapid_link: https://rapid.ensembl.org/Eupsilia_transversa_gca914767815v1/Info/Index
+  alternate: https://rapid.ensembl.org/Eupsilia_transversa_GCA_914767805.1/Info/Index
 
 - species: Fabriciana adippe
   image: Lepidoptera.png
@@ -1191,6 +1243,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/fabriciana_adippe/GCA_905404265.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1
   rapid_link: https://rapid.ensembl.org/Fabriciana_adippe_gca905404265v1/Info/Index
+  alternate: https://rapid.ensembl.org/Fabriciana_adippe_GCA_905404255.1/Info/Index
 
 - species: Furcula furcula
   image: Lepidoptera.png
@@ -1217,6 +1270,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/glaucopsyche_alexis/GCA_905404095.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1
   rapid_link: https://rapid.ensembl.org/Glaucopsyche_alexis_gca905404095v1/Info/Index
+  alternate: https://rapid.ensembl.org/Glaucopsyche_alexis_GCA_905404225.1/Info/Index
 
 - species: Griposia aprilina
   image: Lepidoptera.png
@@ -1230,6 +1284,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/griposia_aprilina/GCA_916610205.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1
   rapid_link: https://rapid.ensembl.org/Griposia_aprilina_gca916610205v1/Info/Index
+  alternate: https://rapid.ensembl.org/Griposia_aprilina_GCA_916610245.1/Info/Index
 
 - species: Gymnosoma rotundatum
   image: Arthropods.png
@@ -1244,6 +1299,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1
   rapid_link: https://rapid.ensembl.org/Gymnosoma_rotundatum_gca916610165v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/gymnosoma_rotundatum_GCA_916610165.1/gymnosoma_rotundatum_gca916610165v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Gymnosoma_rotundatum_GCA_916610175.1/Info/Index
 
 - species: Gymnosoma rotundatum
   image: Arthropods.png
@@ -1257,6 +1313,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnosoma_rotundatum/GCA_916610165.2.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2
   rapid_link: https://rapid.ensembl.org/Gymnosoma_rotundatum_gca916610165v2/Info/Index
+  alternate: https://rapid.ensembl.org/Gymnosoma_rotundatum_GCA_916610175.2/Info/Index
 
 - species: Habrosyne pyritoides
   image: Lepidoptera.png
@@ -1270,6 +1327,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/habrosyne_pyritoides/GCA_907165245.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1
   rapid_link: https://rapid.ensembl.org/Habrosyne_pyritoides_gca907165245v1/Info/Index
+  alternate: https://rapid.ensembl.org/Habrosyne_pyritoides_GCA_907165225.1/Info/Index
 
 - species: Hecatera dysodea
   image: Lepidoptera.png
@@ -1312,6 +1370,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1
   rapid_link: https://rapid.ensembl.org/Hedya_salicella_gca905404275v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hedya_salicella_GCA_905404275.1/hedya_salicella_gca905404275v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Hedya_salicella_GCA_905404235.1/Info/Index
 
 - species: Hemaris fuciformis
   image: Lepidoptera.png
@@ -1326,6 +1385,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1
   rapid_link: https://rapid.ensembl.org/Hemaris_fuciformis_gca907164795v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hemaris_fuciformis_GCA_907164795.1/hemaris_fuciformis_gca907164795v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Hemaris_fuciformis_GCA_907164865.1/Info/Index
 
 - species: Hesperia comma
   image: Lepidoptera.png
@@ -1339,6 +1399,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hesperia_comma/GCA_905404135.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1
   rapid_link: https://rapid.ensembl.org/Hesperia_comma_gca905404135v1/Info/Index
+  alternate: https://rapid.ensembl.org/Hesperia_comma_GCA_905404245.1/Info/Index
 
 - species: Hydraecia micacea
   image: Lepidoptera.png
@@ -1352,6 +1413,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hydraecia_micacea/GCA_914767645.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1
   rapid_link: https://rapid.ensembl.org/Hydraecia_micacea_gca914767645v1/Info/Index
+  alternate: https://rapid.ensembl.org/Hydraecia_micacea_GCA_914767565.1/Info/Index
 
 - species: Hydriomena furcata
   image: Lepidoptera.png
@@ -1365,6 +1427,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hydriomena_furcata/GCA_912999785.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1
   rapid_link: https://rapid.ensembl.org/Hydriomena_furcata_gca912999785v1/Info/Index
+  alternate: https://rapid.ensembl.org/Hydriomena_furcata_GCA_912999755.1/Info/Index
 
 - species: Hylaea fasciaria
   image: Lepidoptera.png
@@ -1378,6 +1441,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hylaea_fasciaria/GCA_905147375.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1
   rapid_link: https://rapid.ensembl.org/Hylaea_fasciaria_gca905147375v1/Info/Index
+  alternate: https://rapid.ensembl.org/Hylaea_fasciaria_GCA_905147295.1/Info/Index
 
 - species: Hypena proboscidalis
   image: Lepidoptera.png
@@ -1392,6 +1456,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1
   rapid_link: https://rapid.ensembl.org/Hypena_proboscidalis_gca905147285v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hypena_proboscidalis_GCA_905147285.1/hypena_proboscidalis_gca905147285v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Hypena_proboscidalis_GCA_905147305.1/Info/Index
 
 - species: Ichneumon xanthorius
   image: Arthropods.png
@@ -1406,6 +1471,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1
   rapid_link: https://rapid.ensembl.org/Ichneumon_xanthorius_gca917499995v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ichneumon_xanthorius_GCA_917499995.1/ichneumon_xanthorius_gca917499995v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ichneumon_xanthorius_GCA_917498535.1/Info/Index
 
 - species: Idaea aversata
   image: Lepidoptera.png
@@ -1420,6 +1486,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1
   rapid_link: https://rapid.ensembl.org/Idaea_aversata_gca907269075v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/idaea_aversata_GCA_907269075.1/idaea_aversata_gca907269075v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Idaea_aversata_GCA_907269045.1/Info/Index
 
 - species: Inachis io
   image: Lepidoptera.png
@@ -1433,6 +1500,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/inachis_io/GCA_905147045.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1
   rapid_link: https://rapid.ensembl.org/Inachis_io_gca905147045v1/Info/Index
+  alternate: https://rapid.ensembl.org/Inachis_io_GCA_905147125.1/Info/Index
 
 - species: Laothoe populi
   image: Lepidoptera.png
@@ -1446,6 +1514,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/laothoe_populi/GCA_905220505.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1
   rapid_link: https://rapid.ensembl.org/Laothoe_populi_gca905220505v1/Info/Index
+  alternate: https://rapid.ensembl.org/Laothoe_populi_GCA_905220495.1/Info/Index
 
 - species: Lasioglossum lativentre
   image: Arthropods.png
@@ -1486,6 +1555,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1
   rapid_link: https://rapid.ensembl.org/Laspeyria_flexula_gca905147015v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/laspeyria_flexula_GCA_905147015.1/laspeyria_flexula_gca905147015v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Laspeyria_flexula_GCA_905147035.1/Info/Index
 
 - species: Leptidea sinapis
   image: Lepidoptera.png
@@ -1499,6 +1569,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/leptidea_sinapis/GCA_905404315.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1
   rapid_link: https://rapid.ensembl.org/Leptidea_sinapis_gca905404315v1/Info/Index
+  alternate: https://rapid.ensembl.org/Leptidea_sinapis_GCA_905404105.1/Info/Index
 
 - species: Limenitis camilla
   image: Lepidoptera.png
@@ -1513,6 +1584,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1
   rapid_link: https://rapid.ensembl.org/Limenitis_camilla_gca905147385v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/limenitis_camilla_GCA_905147385.1/limenitis_camilla_gca905147385v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Limenitis_camilla_GCA_905147315.1/Info/Index
 
 - species: Lineus longissimus
   image: Metazoa.png
@@ -1525,6 +1597,7 @@
   softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/genome/Lineus_longissimus-GCA_910592395.2-softmasked.fa.gz
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2
   rapid_link: https://rapid.ensembl.org/Lineus_longissimus_gca910592395v2/Info/Index
+  alternate: https://rapid.ensembl.org/Lineus_longissimus_GCA_910592375.2/Info/Index
 
 - species: Lycaena phlaeas
   image: Lepidoptera.png
@@ -1538,6 +1611,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lycaena_phlaeas/GCA_905333005.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1
   rapid_link: https://rapid.ensembl.org/Lycaena_phlaeas_gca905333005v1/Info/Index
+  alternate: https://rapid.ensembl.org/Lycaena_phlaeas_GCA_905333065.1/Info/Index
 
 - species: Lymantria monacha
   image: Lepidoptera.png
@@ -1566,6 +1640,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1
   rapid_link: https://rapid.ensembl.org/Lysandra_bellargus_gca905333045v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lysandra_bellargus_GCA_905333045.1/lysandra_bellargus_gca905333045v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Lysandra_bellargus_GCA_905332955.1/Info/Index
 
 - species: Lysandra coridon
   image: Lepidoptera.png
@@ -1580,6 +1655,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1
   rapid_link: https://rapid.ensembl.org/Lysandra_coridon_gca905220515v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lysandra_coridon_GCA_905220515.1/lysandra_coridon_gca905220515v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Lysandra_coridon_GCA_905220525.1/Info/Index
 
 - species: Macropis europaea
   image: Arthropods.png
@@ -1607,6 +1683,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/malachius_bipustulatus/GCA_910589415.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1
   rapid_link: https://rapid.ensembl.org/Malachius_bipustulatus_gca910589415v1/Info/Index
+  alternate: https://rapid.ensembl.org/Malachius_bipustulatus_GCA_910589365.1/Info/Index
 
 - species: Mamestra brassicae
   image: Lepidoptera.png
@@ -1648,6 +1725,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/maniola_jurtina/GCA_905333055.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1
   rapid_link: https://rapid.ensembl.org/Maniola_jurtina_gca905333055v1/Info/Index
+  alternate: https://rapid.ensembl.org/Maniola_jurtina_GCA_905333105.1/Info/Index
 
 - species: Melanargia galathea
   image: Lepidoptera.png
@@ -1662,6 +1740,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1
   rapid_link: https://rapid.ensembl.org/Melanargia_galathea_gca920104075v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/melanargia_galathea_GCA_920104075.1/melanargia_galathea_gca920104075v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Melanargia_galathea_GCA_920103875.1/Info/Index
 
 - species: Melanostoma mellinum
   image: Arthropods.png
@@ -1676,6 +1755,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1
   rapid_link: https://rapid.ensembl.org/Melanostoma_mellinum_gca914767635v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/melanostoma_mellinum_GCA_914767635.1/melanostoma_mellinum_gca914767635v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Melanostoma_mellinum_GCA_914767615.1/Info/Index
 
 - species: Melitaea cinxia
   image: Lepidoptera.png
@@ -1689,6 +1769,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melitaea_cinxia/GCA_905220565.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1
   rapid_link: https://rapid.ensembl.org/Melitaea_cinxia_gca905220565v1/Info/Index
+  alternate: https://rapid.ensembl.org/Melitaea_cinxia_GCA_905220555.1/Info/Index
 
 - species: Mellicta athalia
   image: Lepidoptera.png
@@ -1702,6 +1783,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mellicta_athalia/GCA_905220545.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1
   rapid_link: https://rapid.ensembl.org/Mellicta_athalia_gca905220545v1/Info/Index
+  alternate: https://rapid.ensembl.org/Mellicta_athalia_GCA_905220535.1/Info/Index
 
 - species: Mesoligia furuncula
   image: Lepidoptera.png
@@ -1715,6 +1797,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mesoligia_furuncula/GCA_916614155.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1
   rapid_link: https://rapid.ensembl.org/Mesoligia_furuncula_gca916614155v1/Info/Index
+  alternate: https://rapid.ensembl.org/Mesoligia_furuncula_GCA_916611985.1/Info/Index
 
 - species: Mimas tiliae
   image: Lepidoptera.png
@@ -1728,6 +1811,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mimas_tiliae/GCA_905332985.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1
   rapid_link: https://rapid.ensembl.org/Mimas_tiliae_gca905332985v1/Info/Index
+  alternate: https://rapid.ensembl.org/Mimas_tiliae_GCA_905333085.1/Info/Index
 
 - species: Mimumesa dahlbomi
   image: Arthropods.png
@@ -1754,6 +1838,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/myathropa_florea/GCA_930367185.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1
   rapid_link: https://rapid.ensembl.org/Myathropa_florea_gca930367185v1/Info/Index
+  alternate: https://rapid.ensembl.org/Myathropa_florea_GCA_930367245.1/Info/Index
 
 - species: Mythimna ferrago
   image: Lepidoptera.png
@@ -1768,6 +1853,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1
   rapid_link: https://rapid.ensembl.org/Mythimna_ferrago_gca910589285v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_ferrago_GCA_910589285.1/mythimna_ferrago_gca910589285v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Mythimna_ferrago_GCA_910589535.1/Info/Index
 
 - species: Mythimna ferrago
   image: Lepidoptera.png
@@ -1782,6 +1868,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2
   rapid_link: https://rapid.ensembl.org/Mythimna_ferrago_gca910589285v2/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_ferrago_GCA_910589285.2/mythimna_ferrago_gca910589285v2_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Mythimna_ferrago_GCA_910589535.2/Info/Index
 
 - species: Mythimna impura
   image: Lepidoptera.png
@@ -1796,6 +1883,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1
   rapid_link: https://rapid.ensembl.org/Mythimna_impura_gca905147345v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_impura_GCA_905147345.1/mythimna_impura_gca905147345v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Mythimna_impura_GCA_905147275.1/Info/Index
 
 - species: Mythimna impura
   image: Lepidoptera.png
@@ -1823,6 +1911,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_fimbriata/GCA_905163415.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1
   rapid_link: https://rapid.ensembl.org/Noctua_fimbriata_gca905163415v1/Info/Index
+  alternate: https://rapid.ensembl.org/Noctua_fimbriata_GCA_905163425.1/Info/Index
 
 - species: Noctua janthe
   image: Lepidoptera.png
@@ -1836,6 +1925,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_janthe/GCA_910589295.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1
   rapid_link: https://rapid.ensembl.org/Noctua_janthe_gca910589295v1/Info/Index
+  alternate: https://rapid.ensembl.org/Noctua_janthe_GCA_910589505.1/Info/Index
 
 - species: Noctua pronuba
   image: Lepidoptera.png
@@ -1849,6 +1939,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_pronuba/GCA_905220335.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1
   rapid_link: https://rapid.ensembl.org/Noctua_pronuba_gca905220335v1/Info/Index
+  alternate: https://rapid.ensembl.org/Noctua_pronuba_GCA_905220345.1/Info/Index
 
 - species: Nomada fabriciana
   image: Arthropods.png
@@ -1863,6 +1954,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1
   rapid_link: https://rapid.ensembl.org/Nomada_fabriciana_gca907165295v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nomada_fabriciana_GCA_907165295.1/nomada_fabriciana_gca907165295v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Nomada_fabriciana_GCA_907165305.1/Info/Index
 
 - species: Notocelia uddmanniana
   image: Lepidoptera.png
@@ -1876,6 +1968,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notocelia_uddmanniana/GCA_905163555.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1
   rapid_link: https://rapid.ensembl.org/Notocelia_uddmanniana_gca905163555v1/Info/Index
+  alternate: https://rapid.ensembl.org/Notocelia_uddmanniana_GCA_905163575.1/Info/Index
 
 - species: Notodonta dromedarius
   image: Lepidoptera.png
@@ -1890,6 +1983,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1
   rapid_link: https://rapid.ensembl.org/Notodonta_dromedarius_gca905147325v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/notodonta_dromedarius_GCA_905147325.1/notodonta_dromedarius_gca905147325v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Notodonta_dromedarius_GCA_905147855.1/Info/Index
 
 - species: Nymphalis polychloros
   image: Lepidoptera.png
@@ -1904,6 +1998,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1
   rapid_link: https://rapid.ensembl.org/Nymphalis_polychloros_gca905220585v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_polychloros_GCA_905220585.1/nymphalis_polychloros_gca905220585v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Nymphalis_polychloros_GCA_905220575.1/Info/Index
 
 - species: Nymphalis polychloros
   image: Lepidoptera.png
@@ -1932,6 +2027,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1
   rapid_link: https://rapid.ensembl.org/Nymphalis_urticae_gca905147175v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_urticae_GCA_905147175.1/nymphalis_urticae_gca905147175v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Nymphalis_urticae_GCA_905147055.1/Info/Index
 
 - species: Nymphalis urticae
   image: Lepidoptera.png
@@ -1960,6 +2056,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1
   rapid_link: https://rapid.ensembl.org/Nysson_spinosus_gca910591585v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nysson_spinosus_GCA_910591585.1/nysson_spinosus_gca910591585v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Nysson_spinosus_GCA_910591465.1/Info/Index
 
 - species: Ochlodes sylvanus
   image: Lepidoptera.png
@@ -1974,6 +2071,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1
   rapid_link: https://rapid.ensembl.org/Ochlodes_sylvanus_gca905404295v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ochlodes_sylvanus_GCA_905404295.1/ochlodes_sylvanus_gca905404295v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ochlodes_sylvanus_GCA_905404205.1/Info/Index
 
 - species: Ochropleura plecta
   image: Lepidoptera.png
@@ -1987,6 +2085,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ochropleura_plecta/GCA_905475445.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1
   rapid_link: https://rapid.ensembl.org/Ochropleura_plecta_gca905475445v1/Info/Index
+  alternate: https://rapid.ensembl.org/Ochropleura_plecta_GCA_905475425.1/Info/Index
 
 - species: Ocypus olens
   image: Arthropods.png
@@ -2001,6 +2100,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1
   rapid_link: https://rapid.ensembl.org/Ocypus_olens_gca910593695v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ocypus_olens_GCA_910593695.1/ocypus_olens_gca910593695v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Ocypus_olens_GCA_910593855.1/Info/Index
 
 - species: Omphaloscelis lunosa
   image: Lepidoptera.png
@@ -2014,6 +2114,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/omphaloscelis_lunosa/GCA_916610215.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1
   rapid_link: https://rapid.ensembl.org/Omphaloscelis_lunosa_gca916610215v1/Info/Index
+  alternate: https://rapid.ensembl.org/Omphaloscelis_lunosa_GCA_916610225.1/Info/Index
 
 - species: Orgyia antiqua
   image: Lepidoptera.png
@@ -2027,6 +2128,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/orgyia_antiqua/GCA_916999025.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1
   rapid_link: https://rapid.ensembl.org/Orgyia_antiqua_gca916999025v1/Info/Index
+  alternate: https://rapid.ensembl.org/Orgyia_antiqua_GCA_917414775.1/Info/Index
 
 - species: Osmia bicornis bicornis
   image: Arthropods.png
@@ -2040,6 +2142,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/osmia_bicornis_bicornis/GCA_907164935.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1
   rapid_link: https://rapid.ensembl.org/Osmia_bicornis_gca907164935v1/Info/Index
+  alternate: https://rapid.ensembl.org/Osmia_bicornis_bicornis_GCA_907164925.1/Info/Index
 
 - species: Pammene fasciana
   image: Lepidoptera.png
@@ -2066,6 +2169,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/papilio_machaon/GCA_912999745.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1
   rapid_link: https://rapid.ensembl.org/Papilio_machaon_gca912999745v1/Info/Index
+  alternate: https://rapid.ensembl.org/Papilio_machaon_GCA_912999765.1/Info/Index
 
 - species: Parapoynx stratiotata
   image: Lepidoptera.png
@@ -2079,6 +2183,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parapoynx_stratiotata/GCA_910589355.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1
   rapid_link: https://rapid.ensembl.org/Parapoynx_stratiotata_gca910589355v1/Info/Index
+  alternate: https://rapid.ensembl.org/Parapoynx_stratiotata_GCA_910589245.1/Info/Index
 
 - species: Pararge aegeria
   image: Lepidoptera.png
@@ -2093,6 +2198,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1
   rapid_link: https://rapid.ensembl.org/Pararge_aegeria_gca905163445v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pararge_aegeria_GCA_905163445.1/pararge_aegeria_gca905163445v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Pararge_aegeria_GCA_905163545.1/Info/Index
 
 - species: Patella pellucida
   image: Metazoa.png
@@ -2119,6 +2225,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/peribatodes_rhomboidaria/GCA_911728515.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1
   rapid_link: https://rapid.ensembl.org/Peribatodes_rhomboidaria_gca911728515v1/Info/Index
+  alternate: https://rapid.ensembl.org/Peribatodes_rhomboidaria_GCA_911728505.1/Info/Index
 
 - species: Phalera bucephala
   image: Lepidoptera.png
@@ -2133,6 +2240,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2
   rapid_link: https://rapid.ensembl.org/Phalera_bucephala_gca905147815v2/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/phalera_bucephala_GCA_905147815.2/phalera_bucephala_gca905147815v2_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Phalera_bucephala_GCA_905147805.2/Info/Index
 
 - species: Pheosia gnoma
   image: Lepidoptera.png
@@ -2146,6 +2254,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pheosia_gnoma/GCA_905404115.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1
   rapid_link: https://rapid.ensembl.org/Pheosia_gnoma_gca905404115v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pheosia_gnoma_GCA_905404125.1/Info/Index
 
 - species: Pheosia tremula
   image: Lepidoptera.png
@@ -2160,6 +2269,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1
   rapid_link: https://rapid.ensembl.org/Pheosia_tremula_gca905333125v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pheosia_tremula_GCA_905333125.1/pheosia_tremula_gca905333125v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Pheosia_tremula_GCA_905333115.1/Info/Index
 
 - species: Phlogophora meticulosa
   image: Lepidoptera.png
@@ -2174,6 +2284,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1
   rapid_link: https://rapid.ensembl.org/Phlogophora_meticulosa_gca905147745v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/phlogophora_meticulosa_GCA_905147745.1/phlogophora_meticulosa_gca905147745v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Phlogophora_meticulosa_GCA_905147725.1/Info/Index
 
 - species: Pieris brassicae
   image: Lepidoptera.png
@@ -2187,6 +2298,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_brassicae/GCA_905147105.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1
   rapid_link: https://rapid.ensembl.org/Pieris_brassicae_gca905147105v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pieris_brassicae_GCA_905147085.1/Info/Index
 
 - species: Pieris napi
   image: Lepidoptera.png
@@ -2200,6 +2312,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905231885.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1
   rapid_link: https://rapid.ensembl.org/Pieris_napi_gca905231885v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pieris_napi_GCA_905231895.1/Info/Index
 
 - species: Pieris napi
   image: Lepidoptera.png
@@ -2213,6 +2326,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905475465.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1
   rapid_link: https://rapid.ensembl.org/Pieris_napi_gca905475465v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pieris_napi_GCA_905475415.1/Info/Index
 
 - species: Pieris napi
   image: Lepidoptera.png
@@ -2240,6 +2354,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_rapae/GCA_905147795.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1
   rapid_link: https://rapid.ensembl.org/Pieris_rapae_gca905147795v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pieris_rapae_GCA_905147735.1/Info/Index
 
 - species: Platycheirus albimanus
   image: Arthropods.png
@@ -2253,6 +2368,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/platycheirus_albimanus/GCA_916050605.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1
   rapid_link: https://rapid.ensembl.org/Platycheirus_albimanus_gca916050605v1/Info/Index
+  alternate: https://rapid.ensembl.org/Platycheirus_albimanus_GCA_916050315.1/Info/Index
 
 - species: Platycheirus albimanus
   image: Arthropods.png
@@ -2279,6 +2395,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/plebejus_argus/GCA_905404155.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1
   rapid_link: https://rapid.ensembl.org/Plebejus_argus_gca905404155v1/Info/Index
+  alternate: https://rapid.ensembl.org/Plebejus_argus_GCA_905404165.1/Info/Index
 
 - species: Plebejus argus
   image: Lepidoptera.png
@@ -2306,6 +2423,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pollenia_angustigena/GCA_930367215.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1
   rapid_link: https://rapid.ensembl.org/Pollenia_angustigena_gca930367215v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pollenia_angustigena_GCA_930374645.1/Info/Index
 
 - species: Pterostichus madidus
   image: Arthropods.png
@@ -2319,6 +2437,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pterostichus_madidus/GCA_911728475.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1
   rapid_link: https://rapid.ensembl.org/Pterostichus_madidus_gca911728475v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pterostichus_madidus_GCA_911728425.1/Info/Index
 
 - species: Pterostichus madidus
   image: Arthropods.png
@@ -2345,6 +2464,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ptilodon_capucinus/GCA_914767695.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1
   rapid_link: https://rapid.ensembl.org/Ptilodon_capucinus_gca914767695v1/Info/Index
+  alternate: https://rapid.ensembl.org/Ptilodon_capucinus_GCA_914767775.1/Info/Index
 
 - species: Pyrgus malvae
   image: Lepidoptera.png
@@ -2358,6 +2478,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pyrgus_malvae/GCA_911387765.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1
   rapid_link: https://rapid.ensembl.org/Pyrgus_malvae_gca911387765v1/Info/Index
+  alternate: https://rapid.ensembl.org/Pyrgus_malvae_GCA_911387725.1/Info/Index
 
 - species: Pyrochroa serraticornis
   image: Arthropods.png
@@ -2397,6 +2518,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rhagonycha_fulva/GCA_905340355.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1
   rapid_link: https://rapid.ensembl.org/Rhagonycha_fulva_gca905340355v1/Info/Index
+  alternate: https://rapid.ensembl.org/Rhagonycha_fulva_GCA_905340395.1/Info/Index
 
 - species: Salmo trutta
   image: Fish.png
@@ -2423,6 +2545,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophaga_caerulescens/GCA_927399465.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1
   rapid_link: https://rapid.ensembl.org/Sarcophaga_caerulescens_gca927399465v1/Info/Index
+  alternate: https://rapid.ensembl.org/Sarcophaga_caerulescens_GCA_927399425.1/Info/Index
 
 - species: Sarcophaga rosellei
   image: Arthropods.png
@@ -2436,6 +2559,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophaga_rosellei/GCA_930367235.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1
   rapid_link: https://rapid.ensembl.org/Sarcophaga_rosellei_gca930367235v1/Info/Index
+  alternate: https://rapid.ensembl.org/Sarcophaga_rosellei_GCA_930367195.1/Info/Index
 
 - species: Scaeva pyrastri
   image: Arthropods.png
@@ -2449,6 +2573,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scaeva_pyrastri/GCA_905146935.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1
   rapid_link: https://rapid.ensembl.org/Scaeva_pyrastri_gca905146935v1/Info/Index
+  alternate: https://rapid.ensembl.org/Scaeva_pyrastri_GCA_905147095.1/Info/Index
 
 - species: Schrankia costaestrigalis
   image: Lepidoptera.png
@@ -2462,6 +2587,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/schrankia_costaestrigalis/GCA_905475405.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1
   rapid_link: https://rapid.ensembl.org/Schrankia_costaestrigalis_gca905475405v1/Info/Index
+  alternate: https://rapid.ensembl.org/Schrankia_costaestrigalis_GCA_905475335.1/Info/Index
 
 - species: Sciurus carolinensis
   image: Mammals.png
@@ -2526,6 +2652,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sesia_apiformis/GCA_914767545.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1
   rapid_link: https://rapid.ensembl.org/Sesia_apiformis_gca914767545v1/Info/Index
+  alternate: https://rapid.ensembl.org/Sesia_apiformis_GCA_914767725.1/Info/Index
 
 - species: Sphecodes monilicornis
   image: Arthropods.png
@@ -2552,6 +2679,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/spilarctia_lutea/GCA_916048165.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1
   rapid_link: https://rapid.ensembl.org/Spilarctia_lutea_gca916048165v1/Info/Index
+  alternate: https://rapid.ensembl.org/Spilarctia_lutea_GCA_916047975.1/Info/Index
 
 - species: Spilosoma lubricipeda
   image: Lepidoptera.png
@@ -2565,6 +2693,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/spilosoma_lubricipeda/GCA_905220595.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1
   rapid_link: https://rapid.ensembl.org/Spilosoma_lubricipeda_gca905220595v1/Info/Index
+  alternate: https://rapid.ensembl.org/Spilosoma_lubricipeda_GCA_905220605.1/Info/Index
 
 - species: Syritta pipiens
   image: Arthropods.png
@@ -2578,6 +2707,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/syritta_pipiens/GCA_905187475.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1
   rapid_link: https://rapid.ensembl.org/Syritta_pipiens_gca905187475v1/Info/Index
+  alternate: https://rapid.ensembl.org/Syritta_pipiens_GCA_905147025.1/Info/Index
 
 - species: Tachina fera
   image: Arthropods.png
@@ -2591,6 +2721,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tachina_fera/GCA_905220375.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1
   rapid_link: https://rapid.ensembl.org/Tachina_fera_gca905220375v1/Info/Index
+  alternate: https://rapid.ensembl.org/Tachina_fera_GCA_905220395.1/Info/Index
 
 - species: Tenthredo notha
   image: Arthropods.png
@@ -2605,6 +2736,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1
   rapid_link: https://rapid.ensembl.org/Tenthredo_notha_gca914767705v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tenthredo_notha_GCA_914767705.1/tenthredo_notha_gca914767705v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Tenthredo_notha_GCA_914767975.1/Info/Index
 
 - species: Tenthredo notha
   image: Arthropods.png
@@ -2631,6 +2763,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thecocarcelia_acutangulata/GCA_914767995.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1
   rapid_link: https://rapid.ensembl.org/Thecocarcelia_acutangulata_gca914767995v1/Info/Index
+  alternate: https://rapid.ensembl.org/Thecocarcelia_acutangulata_GCA_914767745.1/Info/Index
 
 - species: Thyatira batis
   image: Lepidoptera.png
@@ -2644,6 +2777,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thyatira_batis/GCA_905147785.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1
   rapid_link: https://rapid.ensembl.org/Thyatira_batis_gca905147785v1/Info/Index
+  alternate: https://rapid.ensembl.org/Thyatira_batis_GCA_905147775.1/Info/Index
 
 - species: Thymelicus sylvestris
   image: Lepidoptera.png
@@ -2657,6 +2791,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thymelicus_sylvestris/GCA_911387775.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1
   rapid_link: https://rapid.ensembl.org/Thymelicus_sylvestris_gca911387775v1/Info/Index
+  alternate: https://rapid.ensembl.org/Thymelicus_sylvestris_GCA_911387695.1/Info/Index
 
 - species: Tinea semifulvella
   image: Lepidoptera.png
@@ -2671,6 +2806,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1
   rapid_link: https://rapid.ensembl.org/Tinea_semifulvella_gca910589645v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tinea_semifulvella_GCA_910589645.1/tinea_semifulvella_gca910589645v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Tinea_semifulvella_GCA_910589255.1/Info/Index
 
 - species: Tinea trinotella
   image: Lepidoptera.png
@@ -2685,6 +2821,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1
   rapid_link: https://rapid.ensembl.org/Tinea_trinotella_gca905220615v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tinea_trinotella_GCA_905220615.1/tinea_trinotella_gca905220615v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Tinea_trinotella_GCA_905220625.1/Info/Index
 
 - species: Trachurus trachurus
   image: Fish.png
@@ -2711,6 +2848,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_atalanta/GCA_905147765.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1
   rapid_link: https://rapid.ensembl.org/Vanessa_atalanta_gca905147765v1/Info/Index
+  alternate: https://rapid.ensembl.org/Vanessa_atalanta_GCA_905147705.1/Info/Index
 
 - species: Vanessa atalanta
   image: Lepidoptera.png
@@ -2724,6 +2862,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_atalanta/GCA_905147765.2.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2
   rapid_link: https://rapid.ensembl.org/Vanessa_atalanta_gca905147765v2/Info/Index
+  alternate: https://rapid.ensembl.org/Vanessa_atalanta_GCA_905147705.2/Info/Index
 
 - species: Vanessa cardui
   image: Lepidoptera.png
@@ -2737,6 +2876,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_cardui/GCA_905220365.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1
   rapid_link: https://rapid.ensembl.org/Vanessa_cardui_gca905220365v1/Info/Index
+  alternate: https://rapid.ensembl.org/Vanessa_cardui_GCA_905220355.1/Info/Index
 
 - species: Vespa crabro
   image: Arthropods.png
@@ -2778,6 +2918,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1
   rapid_link: https://rapid.ensembl.org/Vespula_germanica_gca905340365v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespula_germanica_GCA_905340365.1/vespula_germanica_gca905340365v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Vespula_germanica_GCA_905340295.1/Info/Index
 
 - species: Vespula vulgaris
   image: Arthropods.png
@@ -2792,6 +2933,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1
   rapid_link: https://rapid.ensembl.org/Vespula_vulgaris_gca905475345v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespula_vulgaris_GCA_905475345.1/vespula_vulgaris_gca905475345v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Vespula_vulgaris_GCA_905404185.1/Info/Index
 
 - species: Volucella inanis
   image: Arthropods.png
@@ -2805,6 +2947,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/volucella_inanis/GCA_907269105.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1
   rapid_link: https://rapid.ensembl.org/Volucella_inanis_gca907269105v1/Info/Index
+  alternate: https://rapid.ensembl.org/Volucella_inanis_GCA_907269115.1/Info/Index
 
 - species: Volucella inflata
   image: Arthropods.png
@@ -2818,6 +2961,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/volucella_inflata/GCA_928272305.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1
   rapid_link: https://rapid.ensembl.org/Volucella_inflata_gca928272305v1/Info/Index
+  alternate: https://rapid.ensembl.org/Volucella_inflata_GCA_928272175.1/Info/Index
 
 - species: Xanthogramma pedissequum
   image: Arthropods.png
@@ -2831,6 +2975,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xanthogramma_pedissequum/GCA_910595825.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1
   rapid_link: https://rapid.ensembl.org/Xanthogramma_pedissequum_gca910595825v1/Info/Index
+  alternate: https://rapid.ensembl.org/Xanthogramma_pedissequum_GCA_910595765.1/Info/Index
 
 - species: Xestia xanthographa
   image: Lepidoptera.png
@@ -2845,6 +2990,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1
   rapid_link: https://rapid.ensembl.org/Xestia_xanthographa_gca905147715v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/xestia_xanthographa_GCA_905147715.1/xestia_xanthographa_gca905147715v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Xestia_xanthographa_GCA_905147755.1/Info/Index
 
 - species: Xestia xanthographa
   image: Lepidoptera.png
@@ -2859,6 +3005,7 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2
   rapid_link: https://rapid.ensembl.org/Xestia_xanthographa_gca905147715v2/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/xestia_xanthographa_GCA_905147715.2/xestia_xanthographa_gca905147715v2_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Xestia_xanthographa_GCA_905147755.2/Info/Index
 
 - species: Xylota sylvarum
   image: Arthropods.png
@@ -2872,6 +3019,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xylota_sylvarum/GCA_905220385.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1
   rapid_link: https://rapid.ensembl.org/Xylota_sylvarum_gca905220385v1/Info/Index
+  alternate: https://rapid.ensembl.org/Xylota_sylvarum_GCA_905220405.1/Info/Index
 
 - species: Ypsolopha scabrella
   image: Lepidoptera.png
@@ -2885,6 +3033,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ypsolopha_scabrella/GCA_910592155.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1
   rapid_link: https://rapid.ensembl.org/Ypsolopha_scabrella_gca910592155v1/Info/Index
+  alternate: https://rapid.ensembl.org/Ypsolopha_scabrella_GCA_910591985.1/Info/Index
 
 - species: Zeuzera pyrina
   image: Lepidoptera.png
@@ -2898,6 +3047,7 @@
   repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zeuzera_pyrina/GCA_907165235.1.repeatmodeler.fa
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1
   rapid_link: https://rapid.ensembl.org/Zeuzera_pyrina_gca907165235v1/Info/Index
+  alternate: https://rapid.ensembl.org/Zeuzera_pyrina_GCA_907165255.1/Info/Index
 
 - species: Zygaena filipendulae
   image: Lepidoptera.png
@@ -2912,4 +3062,5 @@
   ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1
   rapid_link: https://rapid.ensembl.org/Zygaena_filipendulae_gca907165275v1/Info/Index
   busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/zygaena_filipendulae_GCA_907165275.1/zygaena_filipendulae_gca907165275v1_busco_short_summary.txt
+  alternate: https://rapid.ensembl.org/Zygaena_filipendulae_GCA_907165265.1/Info/Index
 


### PR DESCRIPTION
By request from the DToL informatics group: add a column on the project page to link out to the alternate assembly (if available)

For each db will check the rapid metadata db (alternates only on RR) for assembly name with "alternate_haplotype" appended (this will work for DToL naming standards but if we update in future to work for other projects we will need to check it works)

I am on the GitHub rota this week, so cannot request myself to review. @ens-ftricomi and @EreboPSilva I've chosen you as you have been most involved with the data, let me know if you would like to sit down and have a quick code review