### PR TITLE
Update ftp links to https

### DIFF
--- a/scripts/projects_page/aquafaang_species.yaml
+++ b/scripts/projects_page/aquafaang_species.yaml
@@ -1,130 +1,130 @@
 - species: Cyprinus carpio
   submitted_by: CHINESE ACADEMY OF FISHERY SCIENCE
   accession: GCA_000951615.2
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/cyprinus_carpio/Cyprinus_carpio.common_carp_genome.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/cyprinus_carpio/Cyprinus_carpio.common_carp_genome.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/cyprinus_carpio/pep/Cyprinus_carpio.common_carp_genome.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/cyprinus_carpio/cdna/Cyprinus_carpio.common_carp_genome.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/cyprinus_carpio/dna/Cyprinus_carpio.common_carp_genome.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyprinus_carpio/GCA_000951615.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/cyprinus_carpio/Cyprinus_carpio.common_carp_genome.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/cyprinus_carpio/Cyprinus_carpio.common_carp_genome.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/cyprinus_carpio/pep/Cyprinus_carpio.common_carp_genome.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/cyprinus_carpio/cdna/Cyprinus_carpio.common_carp_genome.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/cyprinus_carpio/dna/Cyprinus_carpio.common_carp_genome.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyprinus_carpio/GCA_000951615.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Cyprinus_carpio/Info/Index
 
 - species: Cyprinus carpio carpio
   submitted_by: WAGENINGEN UR
   accession: GCA_905221575.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/genome/Cyprinus_carpio_carpio-GCA_905221575.1-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/geneset/2021_08/Cyprinus_carpio_carpio-GCA_905221575.1-2021_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1/genome/Cyprinus_carpio_carpio-GCA_905221575.1-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cyprinus_carpio_carpio/GCA_905221575.1
   rapid_link: https://rapid.ensembl.org/Cyprinus_carpio_gca905221575v1/Info/Index
 
 - species: Dicentrarchus labrax
   submitted_by: MPI-PZ
   accession: GCA_000689215.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/dicentrarchus_labrax/Dicentrarchus_labrax.seabass_V1.0.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/dicentrarchus_labrax/Dicentrarchus_labrax.seabass_V1.0.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/dicentrarchus_labrax/pep/Dicentrarchus_labrax.seabass_V1.0.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/dicentrarchus_labrax/cdna/Dicentrarchus_labrax.seabass_V1.0.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/dicentrarchus_labrax/dna/Dicentrarchus_labrax.seabass_V1.0.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dicentrarchus_labrax/GCA_000689215.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/dicentrarchus_labrax/Dicentrarchus_labrax.seabass_V1.0.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/dicentrarchus_labrax/Dicentrarchus_labrax.seabass_V1.0.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/dicentrarchus_labrax/pep/Dicentrarchus_labrax.seabass_V1.0.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/dicentrarchus_labrax/cdna/Dicentrarchus_labrax.seabass_V1.0.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/dicentrarchus_labrax/dna/Dicentrarchus_labrax.seabass_V1.0.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dicentrarchus_labrax/GCA_000689215.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Dicentrarchus_labrax/Info/Index
 
 - species: Dicentrarchus labrax
   submitted_by: Hellenic Centre for Marine Research, Institute for Marine Biology, Biotechnology and Aquaculture, Heraklion, Crete, Greece
   accession: GCA_905237075.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/genome/Dicentrarchus_labrax-GCA_905237075.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dicentrarchus_labrax/GCA_905237075.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/geneset/2021_08/Dicentrarchus_labrax-GCA_905237075.1-2021_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1/genome/Dicentrarchus_labrax-GCA_905237075.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dicentrarchus_labrax/GCA_905237075.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Dicentrarchus_labrax/GCA_905237075.1
   rapid_link: https://rapid.ensembl.org/Dicentrarchus_labrax_gca905237075v1/Info/Index
 
 - species: Oncorhynchus mykiss
   submitted_by: USDA/ARS
   accession: GCA_002163495.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/oncorhynchus_mykiss/Oncorhynchus_mykiss.Omyk_1.0.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/oncorhynchus_mykiss/Oncorhynchus_mykiss.Omyk_1.0.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/oncorhynchus_mykiss/pep/Oncorhynchus_mykiss.Omyk_1.0.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/oncorhynchus_mykiss/cdna/Oncorhynchus_mykiss.Omyk_1.0.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/oncorhynchus_mykiss/dna/Oncorhynchus_mykiss.Omyk_1.0.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/oncorhynchus_mykiss/Oncorhynchus_mykiss.Omyk_1.0.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/oncorhynchus_mykiss/Oncorhynchus_mykiss.Omyk_1.0.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/oncorhynchus_mykiss/pep/Oncorhynchus_mykiss.Omyk_1.0.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/oncorhynchus_mykiss/cdna/Oncorhynchus_mykiss.Omyk_1.0.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/oncorhynchus_mykiss/dna/Oncorhynchus_mykiss.Omyk_1.0.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Oncorhynchus_mykiss/Info/Index
 
 - species: Oncorhynchus mykiss
   submitted_by: USDA/ARS
   accession: GCA_013265735.3
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/genome/Oncorhynchus_mykiss-GCA_013265735.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/oncorhynchus_mykiss/GCA_013265735.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/geneset/2020_12/Oncorhynchus_mykiss-GCA_013265735.3-2020_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3/genome/Oncorhynchus_mykiss-GCA_013265735.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/oncorhynchus_mykiss/GCA_013265735.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Oncorhynchus_mykiss/GCA_013265735.3
   rapid_link: https://rapid.ensembl.org/Oncorhynchus_mykiss_gca013265735v3/Info/Index
 
 - species: Salmo salar
   submitted_by: International Cooperation to Sequence the Atlantic Salmon Genome
   accession: GCA_000233375.4
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/salmo_salar/Salmo_salar.ICSASG_v2.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/salmo_salar/Salmo_salar.ICSASG_v2.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/salmo_salar/pep/Salmo_salar.ICSASG_v2.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/salmo_salar/cdna/Salmo_salar.ICSASG_v2.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/salmo_salar/dna/Salmo_salar.ICSASG_v2.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_salar/GCA_000233375.4.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/salmo_salar/Salmo_salar.ICSASG_v2.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/salmo_salar/Salmo_salar.ICSASG_v2.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/salmo_salar/pep/Salmo_salar.ICSASG_v2.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/salmo_salar/cdna/Salmo_salar.ICSASG_v2.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/salmo_salar/dna/Salmo_salar.ICSASG_v2.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_salar/GCA_000233375.4.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Salmo_salar/Info/Index
 
 - species: Salmo salar
   submitted_by: NORWEGIAN UNIVERSITY OF LIFE SCIENCES
   accession: GCA_905237065.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/genome/Salmo_salar-GCA_905237065.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_salar/GCA_905237065.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/geneset/2021_07/Salmo_salar-GCA_905237065.2-2021_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2/genome/Salmo_salar-GCA_905237065.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_salar/GCA_905237065.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_salar/GCA_905237065.2
   rapid_link: https://rapid.ensembl.org/Salmo_salar_gca905237065v2/Info/Index
 
 - species: Scophthalmus maximus
   submitted_by: CIGENE
   accession: GCA_013347765.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/scophthalmus_maximus/Scophthalmus_maximus.ASM1334776v1.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/scophthalmus_maximus/Scophthalmus_maximus.ASM1334776v1.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/scophthalmus_maximus/pep/Scophthalmus_maximus.ASM1334776v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/scophthalmus_maximus/cdna/Scophthalmus_maximus.ASM1334776v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/scophthalmus_maximus/dna/Scophthalmus_maximus.ASM1334776v1.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scophthalmus_maximus/GCA_013347765.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/scophthalmus_maximus/Scophthalmus_maximus.ASM1334776v1.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/scophthalmus_maximus/Scophthalmus_maximus.ASM1334776v1.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/scophthalmus_maximus/pep/Scophthalmus_maximus.ASM1334776v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/scophthalmus_maximus/cdna/Scophthalmus_maximus.ASM1334776v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/scophthalmus_maximus/dna/Scophthalmus_maximus.ASM1334776v1.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scophthalmus_maximus/GCA_013347765.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Scophthalmus_maximus/Info/Index
 
 - species: Sparus aurata
   submitted_by: SC
   accession: GCA_900880675.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/sparus_aurata/Sparus_aurata.fSpaAur1.1.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/sparus_aurata/Sparus_aurata.fSpaAur1.1.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/sparus_aurata/pep/Sparus_aurata.fSpaAur1.1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/sparus_aurata/cdna/Sparus_aurata.fSpaAur1.1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/sparus_aurata/dna/Sparus_aurata.fSpaAur1.1.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sparus_aurata/GCA_900880675.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/sparus_aurata/Sparus_aurata.fSpaAur1.1.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/sparus_aurata/Sparus_aurata.fSpaAur1.1.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/sparus_aurata/pep/Sparus_aurata.fSpaAur1.1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/sparus_aurata/cdna/Sparus_aurata.fSpaAur1.1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/sparus_aurata/dna/Sparus_aurata.fSpaAur1.1.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sparus_aurata/GCA_900880675.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Sparus_aurata/Info/Index
 
 - species: Danio rerio
   submitted_by: Genome Reference Consortium
   accession: GCA_000002035.4
-  annotation_gtf: http://ftp.ensembl.org/pub/release-105/gtf/danio_rerio/Danio_rerio.GRCz11.105.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-105/gff3/danio_rerio/Danio_rerio.GRCz11.105.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-105/fasta/danio_rerio/pep/Danio_rerio.GRCz11.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-105/fasta/danio_rerio/cdna/Danio_rerio.GRCz11.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-105/fasta/danio_rerio/dna/Danio_rerio.GRCz11.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/danio_rerio/GCA_000002035.4.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-105
+  annotation_gtf: https://ftp.ensembl.org/pub/release-105/gtf/danio_rerio/Danio_rerio.GRCz11.105.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-105/gff3/danio_rerio/Danio_rerio.GRCz11.105.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-105/fasta/danio_rerio/pep/Danio_rerio.GRCz11.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-105/fasta/danio_rerio/cdna/Danio_rerio.GRCz11.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-105/fasta/danio_rerio/dna/Danio_rerio.GRCz11.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/danio_rerio/GCA_000002035.4.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-105
   ensembl_link: https://www.ensembl.org/Danio_rerio/Info/Index
 

--- a/scripts/projects_page/bovreg_species.yaml
+++ b/scripts/projects_page/bovreg_species.yaml
@@ -1,79 +1,79 @@
 - species: Bos taurus
   submitted_by: USDA ARS
   accession: GCA_002263795.2
-  annotation_gtf: http://ftp.ensembl.org/pub/release-103/gtf/bos_taurus/Bos_taurus.ARS-UCD1.2.103.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-103/gff3/bos_taurus/Bos_taurus.ARS-UCD1.2.103.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-103/fasta/bos_taurus/pep/Bos_taurus.ARS-UCD1.2.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-103/fasta/bos_taurus/cdna/Bos_taurus.ARS-UCD1.2.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-103/fasta/bos_taurus/dna/Bos_taurus.ARS-UCD1.2.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bos_taurus/GCA_002263795.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-103
+  annotation_gtf: https://ftp.ensembl.org/pub/release-103/gtf/bos_taurus/Bos_taurus.ARS-UCD1.2.103.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-103/gff3/bos_taurus/Bos_taurus.ARS-UCD1.2.103.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-103/fasta/bos_taurus/pep/Bos_taurus.ARS-UCD1.2.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-103/fasta/bos_taurus/cdna/Bos_taurus.ARS-UCD1.2.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-103/fasta/bos_taurus/dna/Bos_taurus.ARS-UCD1.2.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bos_taurus/GCA_002263795.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-103
   ensembl_link: https://www.ensembl.org/Bos_taurus/Info/Index
 
 - species: Bos gaurus
   submitted_by: USDA, ARS, USMARC
   accession: GCA_014182915.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/genome/Bos_gaurus-GCA_014182915.1-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/geneset/2020_09/Bos_gaurus-GCA_014182915.1-2020_09-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1/genome/Bos_gaurus-GCA_014182915.1-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bos_gaurus/GCA_014182915.1
   rapid_link: https://rapid.ensembl.org/Bos_gaurus/Info/Index
 
 - species: Bos grunniens
   submitted_by: Lanzhou University
   accession: GCA_005887515.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-103/gtf/bos_grunniens/Bos_grunniens.LU_Bosgru_v3.0.103.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-103/gff3/bos_grunniens/Bos_grunniens.LU_Bosgru_v3.0.103.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-103/fasta/bos_grunniens/pep/Bos_grunniens.LU_Bosgru_v3.0.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-103/fasta/bos_grunniens/cdna/Bos_grunniens.LU_Bosgru_v3.0.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-103/fasta/bos_grunniens/dna/Bos_grunniens.LU_Bosgru_v3.0.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-103
+  annotation_gtf: https://ftp.ensembl.org/pub/release-103/gtf/bos_grunniens/Bos_grunniens.LU_Bosgru_v3.0.103.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-103/gff3/bos_grunniens/Bos_grunniens.LU_Bosgru_v3.0.103.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-103/fasta/bos_grunniens/pep/Bos_grunniens.LU_Bosgru_v3.0.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-103/fasta/bos_grunniens/cdna/Bos_grunniens.LU_Bosgru_v3.0.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-103/fasta/bos_grunniens/dna/Bos_grunniens.LU_Bosgru_v3.0.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-103
   ensembl_link: https://www.ensembl.org/Bos_grunniens/Info/Index
 
 - species: Bos indicus x Bos taurus
   submitted_by: University of Adelaide
   accession: GCA_003369695.2
-  annotation_gtf: http://ftp.ensembl.org/pub/release-103/gtf/bos_indicus_hybrid/Bos_indicus_hybrid.UOA_Brahman_1.103.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-103/gff3/bos_indicus_hybrid/Bos_indicus_hybrid.UOA_Brahman_1.103.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-103/fasta/bos_indicus_hybrid/pep/Bos_indicus_hybrid.UOA_Brahman_1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-103/fasta/bos_indicus_hybrid/cdna/Bos_indicus_hybrid.UOA_Brahman_1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-103/fasta/bos_indicus_hybrid/dna/Bos_indicus_hybrid.UOA_Brahman_1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-103
+  annotation_gtf: https://ftp.ensembl.org/pub/release-103/gtf/bos_indicus_hybrid/Bos_indicus_hybrid.UOA_Brahman_1.103.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-103/gff3/bos_indicus_hybrid/Bos_indicus_hybrid.UOA_Brahman_1.103.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-103/fasta/bos_indicus_hybrid/pep/Bos_indicus_hybrid.UOA_Brahman_1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-103/fasta/bos_indicus_hybrid/cdna/Bos_indicus_hybrid.UOA_Brahman_1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-103/fasta/bos_indicus_hybrid/dna/Bos_indicus_hybrid.UOA_Brahman_1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-103
   ensembl_link: https://www.ensembl.org/Bos_indicus_hybrid/Info/Index
 
 - species: Bos mutus
   submitted_by: BGI-shenzhen
   accession: GCA_000298355.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-103/gtf/bos_mutus/Bos_mutus.BosGru_v2.0.103.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-103/gff3/bos_mutus/Bos_mutus.BosGru_v2.0.103.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-103/fasta/bos_mutus/pep/Bos_mutus.BosGru_v2.0.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-103/fasta/bos_mutus/cdna/Bos_mutus.BosGru_v2.0.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-103/fasta/bos_mutus/dna/Bos_mutus.BosGru_v2.0.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bos_mutus/GCA_000298355.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-103
+  annotation_gtf: https://ftp.ensembl.org/pub/release-103/gtf/bos_mutus/Bos_mutus.BosGru_v2.0.103.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-103/gff3/bos_mutus/Bos_mutus.BosGru_v2.0.103.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-103/fasta/bos_mutus/pep/Bos_mutus.BosGru_v2.0.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-103/fasta/bos_mutus/cdna/Bos_mutus.BosGru_v2.0.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-103/fasta/bos_mutus/dna/Bos_mutus.BosGru_v2.0.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bos_mutus/GCA_000298355.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-103
   ensembl_link: https://www.ensembl.org/Bos_mutus/Info/Index
 
 - species: Bos mutus (Datong Yak)
   submitted_by: Lanzhou University
   accession: GCA_007646595.3
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/genome/Bos_mutus-GCA_007646595.3-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/geneset/2020_08/Bos_mutus-GCA_007646595.3-2020_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3/genome/Bos_mutus-GCA_007646595.3-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bos_mutus/GCA_007646595.3
   rapid_link: https://rapid.ensembl.org/Bos_mutus_datongyak/Info/Index
 
 - species: Bos indicus x Bos taurus
   submitted_by: University of Adelaide
   accession: GCA_003369685.2
-  annotation_gtf: http://ftp.ensembl.org/pub/release-103/gtf/bos_taurus_hybrid/Bos_taurus_hybrid.UOA_Angus_1.103.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-103/gff3/bos_taurus_hybrid/Bos_taurus_hybrid.UOA_Angus_1.103.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-103/fasta/bos_taurus_hybrid/pep/Bos_taurus_hybrid.UOA_Angus_1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-103/fasta/bos_taurus_hybrid/cdna/Bos_taurus_hybrid.UOA_Angus_1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-103/fasta/bos_taurus_hybrid/dna/Bos_taurus_hybrid.UOA_Angus_1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-103
+  annotation_gtf: https://ftp.ensembl.org/pub/release-103/gtf/bos_taurus_hybrid/Bos_taurus_hybrid.UOA_Angus_1.103.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-103/gff3/bos_taurus_hybrid/Bos_taurus_hybrid.UOA_Angus_1.103.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-103/fasta/bos_taurus_hybrid/pep/Bos_taurus_hybrid.UOA_Angus_1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-103/fasta/bos_taurus_hybrid/cdna/Bos_taurus_hybrid.UOA_Angus_1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-103/fasta/bos_taurus_hybrid/dna/Bos_taurus_hybrid.UOA_Angus_1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-103
   ensembl_link: https://www.ensembl.org/Bos_taurus_hybrid/Info/Index
 

--- a/scripts/projects_page/dtol_species.yaml
+++ b/scripts/projects_page/dtol_species.yaml
@@ -2,56 +2,56 @@
   image: Lepidoptera.png
   accession: GCA_905340225.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/genome/Abrostola_tripartita-GCA_905340225.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/abrostola_tripartita/GCA_905340225.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/geneset/2021_11/Abrostola_tripartita-GCA_905340225.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1/genome/Abrostola_tripartita-GCA_905340225.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/abrostola_tripartita/GCA_905340225.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Abrostola_tripartita/GCA_905340225.1
   rapid_link: https://rapid.ensembl.org/Abrostola_tripartita_gca905340225v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/abrostola_tripartita_GCA_905340225.1/abrostola_tripartita_gca905340225v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/abrostola_tripartita_GCA_905340225.1/abrostola_tripartita_gca905340225v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Abrostola_tripartita_GCA_905340255.1/Info/Index
 
 - species: Acronicta aceris
   image: Lepidoptera.png
   accession: GCA_910591435.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/genome/Acronicta_aceris-GCA_910591435.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/acronicta_aceris/GCA_910591435.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/geneset/2021_12/Acronicta_aceris-GCA_910591435.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1/genome/Acronicta_aceris-GCA_910591435.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/acronicta_aceris/GCA_910591435.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Acronicta_aceris/GCA_910591435.1
   rapid_link: https://rapid.ensembl.org/Acronicta_aceris_gca910591435v1/Info/Index
 
 - species: Adalia bipunctata
   image: Arthropods.png
   accession: GCA_910592335.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/genome/Adalia_bipunctata-GCA_910592335.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/adalia_bipunctata/GCA_910592335.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/geneset/2021_12/Adalia_bipunctata-GCA_910592335.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1/genome/Adalia_bipunctata-GCA_910592335.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/adalia_bipunctata/GCA_910592335.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Adalia_bipunctata/GCA_910592335.1
   rapid_link: https://rapid.ensembl.org/Adalia_bipunctata_gca910592335v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/adalia_bipunctata_GCA_910592335.1/adalia_bipunctata_gca910592335v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/adalia_bipunctata_GCA_910592335.1/adalia_bipunctata_gca910592335v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Adalia_bipunctata_GCA_910591895.1/Info/Index
 
 - species: Agriopis aurantiaria
   image: Lepidoptera.png
   accession: GCA_914767915.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agriopis_aurantiaria/GCA_914767915.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/geneset/2021_12/Agriopis_aurantiaria-GCA_914767915.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1/genome/Agriopis_aurantiaria-GCA_914767915.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agriopis_aurantiaria/GCA_914767915.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Agriopis_aurantiaria/GCA_914767915.1
   rapid_link: https://rapid.ensembl.org/Agriopis_aurantiaria_gca914767915v1/Info/Index
   alternate: https://rapid.ensembl.org/Agriopis_aurantiaria_GCA_914767795.1/Info/Index
 
@@ -59,13 +59,13 @@
   image: Lepidoptera.png
   accession: GCA_914767755.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/genome/Agrochola_circellaris-GCA_914767755.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agrochola_circellaris/GCA_914767755.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/geneset/2021_12/Agrochola_circellaris-GCA_914767755.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1/genome/Agrochola_circellaris-GCA_914767755.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agrochola_circellaris/GCA_914767755.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_circellaris/GCA_914767755.1
   rapid_link: https://rapid.ensembl.org/Agrochola_circellaris_gca914767755v1/Info/Index
   alternate: https://rapid.ensembl.org/Agrochola_circellaris_GCA_914767685.1/Info/Index
 
@@ -73,13 +73,13 @@
   image: Lepidoptera.png
   accession: GCA_916701695.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/genome/Agrochola_macilenta-GCA_916701695.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agrochola_macilenta/GCA_916701695.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/geneset/2022_01/Agrochola_macilenta-GCA_916701695.1-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1/genome/Agrochola_macilenta-GCA_916701695.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/agrochola_macilenta/GCA_916701695.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Agrochola_macilenta/GCA_916701695.1
   rapid_link: https://rapid.ensembl.org/Agrochola_macilenta_gca916701695v1/Info/Index
   alternate: https://rapid.ensembl.org/Agrochola_macilenta_GCA_916701705.1/Info/Index
 
@@ -87,72 +87,72 @@
   image: Lepidoptera.png
   accession: GCA_910594945.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/genome/Amphipyra_berbera-GCA_910594945.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amphipyra_berbera/GCA_910594945.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/geneset/2021_11/Amphipyra_berbera-GCA_910594945.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1/genome/Amphipyra_berbera-GCA_910594945.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amphipyra_berbera/GCA_910594945.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.1
   rapid_link: https://rapid.ensembl.org/Amphipyra_berbera_gca910594945v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_berbera_GCA_910594945.1/amphipyra_berbera_gca910594945v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_berbera_GCA_910594945.1/amphipyra_berbera_gca910594945v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Amphipyra_berbera_GCA_910595045.1/Info/Index
 
 - species: Amphipyra berbera
   image: Lepidoptera.png
   accession: GCA_910594945.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/genome/Amphipyra_berbera-GCA_910594945.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amphipyra_berbera/GCA_910594945.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/geneset/2022_03/Amphipyra_berbera-GCA_910594945.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2/genome/Amphipyra_berbera-GCA_910594945.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amphipyra_berbera/GCA_910594945.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_berbera/GCA_910594945.2
   rapid_link: https://rapid.ensembl.org/Amphipyra_berbera_gca910594945v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_berbera_GCA_910594945.2/amphipyra_berbera_gca910594945v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_berbera_GCA_910594945.2/amphipyra_berbera_gca910594945v2_busco_short_summary.txt
 
 - species: Amphipyra tragopoginis
   image: Lepidoptera.png
   accession: GCA_905220435.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/genome/Amphipyra_tragopoginis-GCA_905220435.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amphipyra_tragopoginis/GCA_905220435.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/geneset/2021_11/Amphipyra_tragopoginis-GCA_905220435.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1/genome/Amphipyra_tragopoginis-GCA_905220435.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amphipyra_tragopoginis/GCA_905220435.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Amphipyra_tragopoginis/GCA_905220435.1
   rapid_link: https://rapid.ensembl.org/Amphipyra_tragopoginis_gca905220435v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_tragopoginis_GCA_905220435.1/amphipyra_tragopoginis_gca905220435v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/amphipyra_tragopoginis_GCA_905220435.1/amphipyra_tragopoginis_gca905220435v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Amphipyra_tragopoginis_GCA_905220425.1/Info/Index
 
 - species: Ancistrocerus nigricornis
   image: Arthropods.png
   accession: GCA_916049575.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/genome/Ancistrocerus_nigricornis-GCA_916049575.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ancistrocerus_nigricornis/GCA_916049575.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/geneset/2021_11/Ancistrocerus_nigricornis-GCA_916049575.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1/genome/Ancistrocerus_nigricornis-GCA_916049575.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ancistrocerus_nigricornis/GCA_916049575.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ancistrocerus_nigricornis/GCA_916049575.1
   rapid_link: https://rapid.ensembl.org/Ancistrocerus_nigricornis_gca916049575v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ancistrocerus_nigricornis_GCA_916049575.1/ancistrocerus_nigricornis_gca916049575v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ancistrocerus_nigricornis_GCA_916049575.1/ancistrocerus_nigricornis_gca916049575v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ancistrocerus_nigricornis_GCA_916050135.1/Info/Index
 
 - species: Andrena dorsata
   image: Arthropods.png
   accession: GCA_929108735.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/genome/Andrena_dorsata-GCA_929108735.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_dorsata/GCA_929108735.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/geneset/2022_03/Andrena_dorsata-GCA_929108735.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1/genome/Andrena_dorsata-GCA_929108735.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_dorsata/GCA_929108735.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_dorsata/GCA_929108735.1
   rapid_link: https://rapid.ensembl.org/Andrena_dorsata_gca929108735v1/Info/Index
   alternate: https://rapid.ensembl.org/Andrena_dorsata_GCA_929114765.1/Info/Index
 
@@ -160,28 +160,28 @@
   image: Arthropods.png
   accession: GCA_910592295.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/genome/Andrena_haemorrhoa-GCA_910592295.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_haemorrhoa/GCA_910592295.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/geneset/2021_11/Andrena_haemorrhoa-GCA_910592295.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1/genome/Andrena_haemorrhoa-GCA_910592295.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_haemorrhoa/GCA_910592295.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_haemorrhoa/GCA_910592295.1
   rapid_link: https://rapid.ensembl.org/Andrena_haemorrhoa_gca910592295v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/andrena_haemorrhoa_GCA_910592295.1/andrena_haemorrhoa_gca910592295v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/andrena_haemorrhoa_GCA_910592295.1/andrena_haemorrhoa_gca910592295v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Andrena_haemorrhoa_GCA_910592125.1/Info/Index
 
 - species: Andrena minutula
   image: Arthropods.png
   accession: GCA_929113495.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/genome/Andrena_minutula-GCA_929113495.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_minutula/GCA_929113495.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/geneset/2022_03/Andrena_minutula-GCA_929113495.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1/genome/Andrena_minutula-GCA_929113495.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/andrena_minutula/GCA_929113495.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Andrena_minutula/GCA_929113495.1
   rapid_link: https://rapid.ensembl.org/Andrena_minutula_gca929113495v1/Info/Index
   alternate: https://rapid.ensembl.org/Andrena_minutula_GCA_929113085.1/Info/Index
 
@@ -189,13 +189,13 @@
   image: Arthropods.png
   accession: GCA_914767735.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/genome/Anoplius_nigerrimus-GCA_914767735.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anoplius_nigerrimus/GCA_914767735.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/geneset/2022_02/Anoplius_nigerrimus-GCA_914767735.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1/genome/Anoplius_nigerrimus-GCA_914767735.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anoplius_nigerrimus/GCA_914767735.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Anoplius_nigerrimus/GCA_914767735.1
   rapid_link: https://rapid.ensembl.org/Anoplius_nigerrimus_gca914767735v1/Info/Index
   alternate: https://rapid.ensembl.org/Anoplius_nigerrimus_GCA_914767785.1/Info/Index
 
@@ -203,13 +203,13 @@
   image: Lepidoptera.png
   accession: GCA_905404175.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/genome/Anthocharis_cardamines-GCA_905404175.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anthocharis_cardamines/GCA_905404175.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/geneset/2021_11/Anthocharis_cardamines-GCA_905404175.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1/genome/Anthocharis_cardamines-GCA_905404175.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anthocharis_cardamines/GCA_905404175.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Anthocharis_cardamines/GCA_905404175.1
   rapid_link: https://rapid.ensembl.org/Anthocharis_cardamines_gca905404175v1/Info/Index
   alternate: https://rapid.ensembl.org/Anthocharis_cardamines_GCA_905404305.1/Info/Index
 
@@ -217,13 +217,13 @@
   image: Lepidoptera.png
   accession: GCA_911387795.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/genome/Apamea_monoglypha-GCA_911387795.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/apamea_monoglypha/GCA_911387795.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/geneset/2022_03/Apamea_monoglypha-GCA_911387795.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2/genome/Apamea_monoglypha-GCA_911387795.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/apamea_monoglypha/GCA_911387795.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Apamea_monoglypha/GCA_911387795.2
   rapid_link: https://rapid.ensembl.org/Apamea_monoglypha_gca911387795v2/Info/Index
   alternate: https://rapid.ensembl.org/Apamea_monoglypha_GCA_911387735.2/Info/Index
 
@@ -231,121 +231,121 @@
   image: Lepidoptera.png
   accession: GCA_912999735.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/genome/Aporia_crataegi-GCA_912999735.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aporia_crataegi/GCA_912999735.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/geneset/2021_11/Aporia_crataegi-GCA_912999735.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1/genome/Aporia_crataegi-GCA_912999735.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aporia_crataegi/GCA_912999735.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Aporia_crataegi/GCA_912999735.1
   rapid_link: https://rapid.ensembl.org/Aporia_crataegi_gca912999735v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/aporia_crataegi_GCA_912999735.1/aporia_crataegi_gca912999735v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/aporia_crataegi_GCA_912999735.1/aporia_crataegi_gca912999735v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Aporia_crataegi_GCA_912999795.1/Info/Index
 
 - species: Apotomis turbidana
   image: Lepidoptera.png
   accession: GCA_905147355.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/genome/Apotomis_turbidana-GCA_905147355.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/apotomis_turbidana/GCA_905147355.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/geneset/2022_03/Apotomis_turbidana-GCA_905147355.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2/genome/Apotomis_turbidana-GCA_905147355.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/apotomis_turbidana/GCA_905147355.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Apotomis_turbidana/GCA_905147355.2
   rapid_link: https://rapid.ensembl.org/Apotomis_turbidana_gca905147355v2/Info/Index
 
 - species: Aquila chrysaetos chrysaetos
   image: Birds.png
   accession: GCA_900496995.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/genome/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aquila_chrysaetos_chrysaetos/GCA_900496995.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/genome/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aquila_chrysaetos_chrysaetos/GCA_900496995.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2
   ensembl_link: https://www.ensembl.org/Aquila_chrysaetos_chrysaetos/Info/Index
 
 - species: Aricia agestis
   image: Lepidoptera.png
   accession: GCA_905147365.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/genome/Aricia_agestis-GCA_905147365.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aricia_agestis/GCA_905147365.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/geneset/2021_11/Aricia_agestis-GCA_905147365.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1/genome/Aricia_agestis-GCA_905147365.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aricia_agestis/GCA_905147365.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Aricia_agestis/GCA_905147365.1
   rapid_link: https://rapid.ensembl.org/Aricia_agestis_gca905147365v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/aricia_agestis_GCA_905147365.1/aricia_agestis_gca905147365v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/aricia_agestis_GCA_905147365.1/aricia_agestis_gca905147365v1_busco_short_summary.txt
 
 - species: Arvicola amphibius
   image: Mammals.png
   accession: GCA_903992535.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/genome/Arvicola_amphibius-GCA_903992535.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/arvicola_amphibius/GCA_903992535.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/geneset/2020_12/Arvicola_amphibius-GCA_903992535.1-2020_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1/genome/Arvicola_amphibius-GCA_903992535.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/arvicola_amphibius/GCA_903992535.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Arvicola_amphibius/GCA_903992535.1
   rapid_link: https://rapid.ensembl.org/Arvicola_amphibius_gca903992535v1/Info/Index
 
 - species: Asterias rubens
   image: Metazoa.png
   accession: GCA_902459465.3
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/genome/Asterias_rubens-GCA_902459465.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/asterias_rubens/GCA_902459465.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/geneset/2020_11/Asterias_rubens-GCA_902459465.3-2020_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3/genome/Asterias_rubens-GCA_902459465.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/asterias_rubens/GCA_902459465.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Asterias_rubens/GCA_902459465.3
   rapid_link: https://rapid.ensembl.org/Asterias_rubens_gca902459465v3/Info/Index
 
 - species: Atethmia centrago
   image: Lepidoptera.png
   accession: GCA_905333075.3
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/genome/Atethmia_centrago-GCA_905333075.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/atethmia_centrago/GCA_905333075.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/geneset/2022_03/Atethmia_centrago-GCA_905333075.3-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3/genome/Atethmia_centrago-GCA_905333075.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/atethmia_centrago/GCA_905333075.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Atethmia_centrago/GCA_905333075.3
   rapid_link: https://rapid.ensembl.org/Atethmia_centrago_gca905333075v3/Info/Index
 
 - species: Athalia rosae
   image: Arthropods.png
   accession: GCA_917208135.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/genome/Athalia_rosae-GCA_917208135.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/athalia_rosae/GCA_917208135.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/geneset/2021_11/Athalia_rosae-GCA_917208135.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1/genome/Athalia_rosae-GCA_917208135.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/athalia_rosae/GCA_917208135.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Athalia_rosae/GCA_917208135.1
   rapid_link: https://rapid.ensembl.org/Athalia_rosae_gca917208135v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/athalia_rosae_GCA_917208135.1/athalia_rosae_gca917208135v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/athalia_rosae_GCA_917208135.1/athalia_rosae_gca917208135v1_busco_short_summary.txt
 
 - species: Autographa pulchrina
   image: Lepidoptera.png
   accession: GCA_905475315.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/genome/Autographa_pulchrina-GCA_905475315.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/autographa_pulchrina/GCA_905475315.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/geneset/2021_11/Autographa_pulchrina-GCA_905475315.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1/genome/Autographa_pulchrina-GCA_905475315.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/autographa_pulchrina/GCA_905475315.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Autographa_pulchrina/GCA_905475315.1
   rapid_link: https://rapid.ensembl.org/Autographa_pulchrina_gca905475315v1/Info/Index
   alternate: https://rapid.ensembl.org/Autographa_pulchrina_GCA_905475435.1/Info/Index
 
@@ -353,25 +353,25 @@
   image: Arthropods.png
   accession: GCA_916048285.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/genome/Bellardia_pandia-GCA_916048285.2-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/geneset/2022_03/Bellardia_pandia-GCA_916048285.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2/genome/Bellardia_pandia-GCA_916048285.2-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bellardia_pandia/GCA_916048285.2
   rapid_link: https://rapid.ensembl.org/Bellardia_pandia_gca916048285v2/Info/Index
 
 - species: Bembecia ichneumoniformis
   image: Lepidoptera.png
   accession: GCA_910589475.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/genome/Bembecia_ichneumoniformis-GCA_910589475.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bembecia_ichneumoniformis/GCA_910589475.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/geneset/2021_11/Bembecia_ichneumoniformis-GCA_910589475.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1/genome/Bembecia_ichneumoniformis-GCA_910589475.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bembecia_ichneumoniformis/GCA_910589475.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bembecia_ichneumoniformis/GCA_910589475.1
   rapid_link: https://rapid.ensembl.org/Bembecia_ichneumoniformis_gca910589475v1/Info/Index
   alternate: https://rapid.ensembl.org/Bembecia_ichneumoniformis_GCA_910589565.1/Info/Index
 
@@ -379,13 +379,13 @@
   image: Lepidoptera.png
   accession: GCA_905404145.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/genome/Biston_betularia-GCA_905404145.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/biston_betularia/GCA_905404145.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/geneset/2021_11/Biston_betularia-GCA_905404145.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1/genome/Biston_betularia-GCA_905404145.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/biston_betularia/GCA_905404145.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.1
   rapid_link: https://rapid.ensembl.org/Biston_betularia_gca905404145v1/Info/Index
   alternate: https://rapid.ensembl.org/Biston_betularia_GCA_905404215.1/Info/Index
 
@@ -393,140 +393,140 @@
   image: Lepidoptera.png
   accession: GCA_905404145.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/genome/Biston_betularia-GCA_905404145.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/biston_betularia/GCA_905404145.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/geneset/2022_03/Biston_betularia-GCA_905404145.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2/genome/Biston_betularia-GCA_905404145.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/biston_betularia/GCA_905404145.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Biston_betularia/GCA_905404145.2
   rapid_link: https://rapid.ensembl.org/Biston_betularia_gca905404145v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/biston_betularia_GCA_905404145.2/biston_betularia_gca905404145v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/biston_betularia_GCA_905404145.2/biston_betularia_gca905404145v2_busco_short_summary.txt
 
 - species: Blastobasis adustella
   image: Lepidoptera.png
   accession: GCA_907269095.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/genome/Blastobasis_adustella-GCA_907269095.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/blastobasis_adustella/GCA_907269095.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/geneset/2021_11/Blastobasis_adustella-GCA_907269095.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1/genome/Blastobasis_adustella-GCA_907269095.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/blastobasis_adustella/GCA_907269095.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_adustella/GCA_907269095.1
   rapid_link: https://rapid.ensembl.org/Blastobasis_adustella_gca907269095v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/blastobasis_adustella_GCA_907269095.1/blastobasis_adustella_gca907269095v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/blastobasis_adustella_GCA_907269095.1/blastobasis_adustella_gca907269095v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Blastobasis_adustella_GCA_907269055.1/Info/Index
 
 - species: Blastobasis lacticolella
   image: Lepidoptera.png
   accession: GCA_905147135.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/genome/Blastobasis_lacticolella-GCA_905147135.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/blastobasis_lacticolella/GCA_905147135.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/geneset/2021_11/Blastobasis_lacticolella-GCA_905147135.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1/genome/Blastobasis_lacticolella-GCA_905147135.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/blastobasis_lacticolella/GCA_905147135.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Blastobasis_lacticolella/GCA_905147135.1
   rapid_link: https://rapid.ensembl.org/Blastobasis_lacticolella_gca905147135v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/blastobasis_lacticolella_GCA_905147135.1/blastobasis_lacticolella_gca905147135v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/blastobasis_lacticolella_GCA_905147135.1/blastobasis_lacticolella_gca905147135v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Blastobasis_lacticolella_GCA_905147205.1/Info/Index
 
 - species: Boloria selene
   image: Lepidoptera.png
   accession: GCA_905231865.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/genome/Boloria_selene-GCA_905231865.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/boloria_selene/GCA_905231865.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/geneset/2021_12/Boloria_selene-GCA_905231865.2-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2/genome/Boloria_selene-GCA_905231865.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/boloria_selene/GCA_905231865.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Boloria_selene/GCA_905231865.2
   rapid_link: https://rapid.ensembl.org/Boloria_selene_gca905231865v2/Info/Index
 
 - species: Bombus campestris
   image: Arthropods.png
   accession: GCA_905333015.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/genome/Bombus_campestris-GCA_905333015.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_campestris/GCA_905333015.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/geneset/2021_11/Bombus_campestris-GCA_905333015.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1/genome/Bombus_campestris-GCA_905333015.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_campestris/GCA_905333015.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.1
   rapid_link: https://rapid.ensembl.org/Bombus_campestris_gca905333015v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_campestris_GCA_905333015.1/bombus_campestris_gca905333015v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_campestris_GCA_905333015.1/bombus_campestris_gca905333015v1_busco_short_summary.txt
 
 - species: Bombus campestris
   image: Arthropods.png
   accession: GCA_905333015.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/genome/Bombus_campestris-GCA_905333015.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_campestris/GCA_905333015.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/geneset/2022_03/Bombus_campestris-GCA_905333015.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2/genome/Bombus_campestris-GCA_905333015.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_campestris/GCA_905333015.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_campestris/GCA_905333015.2
   rapid_link: https://rapid.ensembl.org/Bombus_campestris_gca905333015v2/Info/Index
 
 - species: Bombus hortorum
   image: Arthropods.png
   accession: GCA_905332935.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/genome/Bombus_hortorum-GCA_905332935.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_hortorum/GCA_905332935.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/geneset/2021_11/Bombus_hortorum-GCA_905332935.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1/genome/Bombus_hortorum-GCA_905332935.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_hortorum/GCA_905332935.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hortorum/GCA_905332935.1
   rapid_link: https://rapid.ensembl.org/Bombus_hortorum_gca905332935v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_hortorum_GCA_905332935.1/bombus_hortorum_gca905332935v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_hortorum_GCA_905332935.1/bombus_hortorum_gca905332935v1_busco_short_summary.txt
 
 - species: Bombus hypnorum
   image: Arthropods.png
   accession: GCA_911387925.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/genome/Bombus_hypnorum-GCA_911387925.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_hypnorum/GCA_911387925.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/geneset/2021_11/Bombus_hypnorum-GCA_911387925.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1/genome/Bombus_hypnorum-GCA_911387925.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_hypnorum/GCA_911387925.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_hypnorum/GCA_911387925.1
   rapid_link: https://rapid.ensembl.org/Bombus_hypnorum_gca911387925v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_hypnorum_GCA_911387925.1/bombus_hypnorum_gca911387925v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_hypnorum_GCA_911387925.1/bombus_hypnorum_gca911387925v1_busco_short_summary.txt
 
 - species: Bombus pascuorum
   image: Arthropods.png
   accession: GCA_905332965.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/genome/Bombus_pascuorum-GCA_905332965.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_pascuorum/GCA_905332965.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/geneset/2021_11/Bombus_pascuorum-GCA_905332965.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1/genome/Bombus_pascuorum-GCA_905332965.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_pascuorum/GCA_905332965.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pascuorum/GCA_905332965.1
   rapid_link: https://rapid.ensembl.org/Bombus_pascuorum_gca905332965v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_pascuorum_GCA_905332965.1/bombus_pascuorum_gca905332965v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_pascuorum_GCA_905332965.1/bombus_pascuorum_gca905332965v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Bombus_pascuorum_GCA_905332995.1/Info/Index
 
 - species: Bombus pratorum
   image: Arthropods.png
   accession: GCA_930367275.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/genome/Bombus_pratorum-GCA_930367275.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_pratorum/GCA_930367275.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/geneset/2022_03/Bombus_pratorum-GCA_930367275.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1/genome/Bombus_pratorum-GCA_930367275.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_pratorum/GCA_930367275.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_pratorum/GCA_930367275.1
   rapid_link: https://rapid.ensembl.org/Bombus_pratorum_gca930367275v1/Info/Index
   alternate: https://rapid.ensembl.org/Bombus_pratorum_GCA_930367225.1/Info/Index
 
@@ -534,54 +534,54 @@
   image: Arthropods.png
   accession: GCA_911622165.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/genome/Bombus_sylvestris-GCA_911622165.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_sylvestris/GCA_911622165.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/geneset/2021_11/Bombus_sylvestris-GCA_911622165.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1/genome/Bombus_sylvestris-GCA_911622165.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_sylvestris/GCA_911622165.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_sylvestris/GCA_911622165.1
   rapid_link: https://rapid.ensembl.org/Bombus_sylvestris_gca911622165v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_sylvestris_GCA_911622165.1/bombus_sylvestris_gca911622165v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_sylvestris_GCA_911622165.1/bombus_sylvestris_gca911622165v1_busco_short_summary.txt
 
 - species: Bombus terrestris
   image: Arthropods.png
   accession: GCA_000214255.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/genome/Bombus_terrestris-GCA_000214255.1-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/geneset/2021_11/Bombus_terrestris-GCA_000214255.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1/genome/Bombus_terrestris-GCA_000214255.1-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_000214255.1
   rapid_link: https://rapid.ensembl.org/Bombus_terrestris_gca000214255v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_terrestris_GCA_000214255.1/bombus_terrestris_gca000214255v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_terrestris_GCA_000214255.1/bombus_terrestris_gca000214255v1_busco_short_summary.txt
 
 - species: Bombus terrestris
   image: Arthropods.png
   accession: GCA_910591885.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/genome/Bombus_terrestris-GCA_910591885.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_terrestris/GCA_910591885.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/geneset/2021_11/Bombus_terrestris-GCA_910591885.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1/genome/Bombus_terrestris-GCA_910591885.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_terrestris/GCA_910591885.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.1
   rapid_link: https://rapid.ensembl.org/Bombus_terrestris_gca910591885v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_terrestris_GCA_910591885.1/bombus_terrestris_gca910591885v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/bombus_terrestris_GCA_910591885.1/bombus_terrestris_gca910591885v1_busco_short_summary.txt
 
 - species: Bombus terrestris
   image: Arthropods.png
   accession: GCA_910591885.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/genome/Bombus_terrestris-GCA_910591885.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_terrestris/GCA_910591885.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/geneset/2022_03/Bombus_terrestris-GCA_910591885.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2/genome/Bombus_terrestris-GCA_910591885.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/bombus_terrestris/GCA_910591885.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Bombus_terrestris/GCA_910591885.2
   rapid_link: https://rapid.ensembl.org/Bombus_terrestris_gca910591885v2/Info/Index
   alternate: https://rapid.ensembl.org/Bombus_terrestris_GCA_910592195.2/Info/Index
 
@@ -589,13 +589,13 @@
   image: Lepidoptera.png
   accession: GCA_912999815.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/genome/Campaea_margaritaria-GCA_912999815.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/campaea_margaritaria/GCA_912999815.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/geneset/2021_12/Campaea_margaritaria-GCA_912999815.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1/genome/Campaea_margaritaria-GCA_912999815.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/campaea_margaritaria/GCA_912999815.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Campaea_margaritaria/GCA_912999815.1
   rapid_link: https://rapid.ensembl.org/Campaea_margaritaria_gca912999815v1/Info/Index
   alternate: https://rapid.ensembl.org/Campaea_margaritaria_GCA_912999775.1/Info/Index
 
@@ -603,26 +603,26 @@
   image: Mammals.png
   accession: GCA_905319855.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/genome/Canis_lupus-GCA_905319855.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/canis_lupus/GCA_905319855.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/geneset/2022_01/Canis_lupus-GCA_905319855.2-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2/genome/Canis_lupus-GCA_905319855.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/canis_lupus/GCA_905319855.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Canis_lupus/GCA_905319855.2
   rapid_link: https://rapid.ensembl.org/Canis_lupus_gca905319855v2/Info/Index
 
 - species: Cantharis rustica
   image: Arthropods.png
   accession: GCA_911387805.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/genome/Cantharis_rustica-GCA_911387805.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cantharis_rustica/GCA_911387805.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/geneset/2022_02/Cantharis_rustica-GCA_911387805.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1/genome/Cantharis_rustica-GCA_911387805.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cantharis_rustica/GCA_911387805.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cantharis_rustica/GCA_911387805.1
   rapid_link: https://rapid.ensembl.org/Cantharis_rustica_gca911387805v1/Info/Index
   alternate: https://rapid.ensembl.org/Cantharis_rustica_GCA_911387815.1/Info/Index
 
@@ -630,26 +630,26 @@
   image: Lepidoptera.png
   accession: GCA_910589575.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/genome/Carcina_quercana-GCA_910589575.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/carcina_quercana/GCA_910589575.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/geneset/2021_12/Carcina_quercana-GCA_910589575.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1/genome/Carcina_quercana-GCA_910589575.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/carcina_quercana/GCA_910589575.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Carcina_quercana/GCA_910589575.1
   rapid_link: https://rapid.ensembl.org/Carcina_quercana_gca910589575v1/Info/Index
 
 - species: Celastrina argiolus
   image: Lepidoptera.png
   accession: GCA_905187575.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/genome/Celastrina_argiolus-GCA_905187575.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/celastrina_argiolus/GCA_905187575.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/geneset/2021_05/Celastrina_argiolus-GCA_905187575.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1/genome/Celastrina_argiolus-GCA_905187575.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/celastrina_argiolus/GCA_905187575.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Celastrina_argiolus/GCA_905187575.1
   rapid_link: https://rapid.ensembl.org/Celastrina_argiolus_gca905187575v1/Info/Index
   alternate: https://rapid.ensembl.org/Celastrina_argiolus_GCA_905147145.1/Info/Index
 
@@ -657,27 +657,27 @@
   image: Arthropods.png
   accession: GCA_910591515.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/genome/Cerceris_rybyensis-GCA_910591515.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cerceris_rybyensis/GCA_910591515.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/geneset/2021_11/Cerceris_rybyensis-GCA_910591515.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1/genome/Cerceris_rybyensis-GCA_910591515.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cerceris_rybyensis/GCA_910591515.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cerceris_rybyensis/GCA_910591515.1
   rapid_link: https://rapid.ensembl.org/Cerceris_rybyensis_gca910591515v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/cerceris_rybyensis_GCA_910591515.1/cerceris_rybyensis_gca910591515v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/cerceris_rybyensis_GCA_910591515.1/cerceris_rybyensis_gca910591515v1_busco_short_summary.txt
 
 - species: Cheilosia vulpina
   image: Arthropods.png
   accession: GCA_916610125.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/genome/Cheilosia_vulpina-GCA_916610125.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cheilosia_vulpina/GCA_916610125.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/geneset/2022_02/Cheilosia_vulpina-GCA_916610125.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1/genome/Cheilosia_vulpina-GCA_916610125.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cheilosia_vulpina/GCA_916610125.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cheilosia_vulpina/GCA_916610125.1
   rapid_link: https://rapid.ensembl.org/Cheilosia_vulpina_gca916610125v1/Info/Index
   alternate: https://rapid.ensembl.org/Cheilosia_vulpina_GCA_916610195.1/Info/Index
 
@@ -685,13 +685,13 @@
   image: Lepidoptera.png
   accession: GCA_910589605.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/genome/Chrysoteuchia_culmella-GCA_910589605.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chrysoteuchia_culmella/GCA_910589605.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/geneset/2021_12/Chrysoteuchia_culmella-GCA_910589605.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1/genome/Chrysoteuchia_culmella-GCA_910589605.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chrysoteuchia_culmella/GCA_910589605.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Chrysoteuchia_culmella/GCA_910589605.1
   rapid_link: https://rapid.ensembl.org/Chrysoteuchia_culmella_gca910589605v1/Info/Index
   alternate: https://rapid.ensembl.org/Chrysoteuchia_culmella_GCA_910589405.1/Info/Index
 
@@ -699,72 +699,72 @@
   image: Arthropods.png
   accession: GCA_911387755.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/genome/Chrysotoxum_bicinctum-GCA_911387755.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chrysotoxum_bicinctum/GCA_911387755.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/geneset/2021_12/Chrysotoxum_bicinctum-GCA_911387755.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1/genome/Chrysotoxum_bicinctum-GCA_911387755.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chrysotoxum_bicinctum/GCA_911387755.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Chrysotoxum_bicinctum/GCA_911387755.1
   rapid_link: https://rapid.ensembl.org/Chrysotoxum_bicinctum_gca911387755v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/chrysotoxum_bicinctum_GCA_911387755.1/chrysotoxum_bicinctum_gca911387755v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/chrysotoxum_bicinctum_GCA_911387755.1/chrysotoxum_bicinctum_gca911387755v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Chrysotoxum_bicinctum_GCA_911387745.1/Info/Index
 
 - species: Clostera curtula
   image: Lepidoptera.png
   accession: GCA_905475355.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/genome/Clostera_curtula-GCA_905475355.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/clostera_curtula/GCA_905475355.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/geneset/2021_11/Clostera_curtula-GCA_905475355.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1/genome/Clostera_curtula-GCA_905475355.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/clostera_curtula/GCA_905475355.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.1
   rapid_link: https://rapid.ensembl.org/Clostera_curtula_gca905475355v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/clostera_curtula_GCA_905475355.1/clostera_curtula_gca905475355v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/clostera_curtula_GCA_905475355.1/clostera_curtula_gca905475355v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Clostera_curtula_GCA_905475325.1/Info/Index
 
 - species: Clostera curtula
   image: Lepidoptera.png
   accession: GCA_905475355.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/genome/Clostera_curtula-GCA_905475355.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/clostera_curtula/GCA_905475355.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/geneset/2022_03/Clostera_curtula-GCA_905475355.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2/genome/Clostera_curtula-GCA_905475355.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/clostera_curtula/GCA_905475355.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Clostera_curtula/GCA_905475355.2
   rapid_link: https://rapid.ensembl.org/Clostera_curtula_gca905475355v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/clostera_curtula_GCA_905475355.2/clostera_curtula_gca905475355v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/clostera_curtula_GCA_905475355.2/clostera_curtula_gca905475355v2_busco_short_summary.txt
 
 - species: Coccinella septempunctata
   image: Arthropods.png
   accession: GCA_907165205.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/genome/Coccinella_septempunctata-GCA_907165205.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/coccinella_septempunctata/GCA_907165205.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/geneset/2021_12/Coccinella_septempunctata-GCA_907165205.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1/genome/Coccinella_septempunctata-GCA_907165205.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/coccinella_septempunctata/GCA_907165205.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Coccinella_septempunctata/GCA_907165205.1
   rapid_link: https://rapid.ensembl.org/Coccinella_septempunctata_gca907165205v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/coccinella_septempunctata_GCA_907165205.1/coccinella_septempunctata_gca907165205v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/coccinella_septempunctata_GCA_907165205.1/coccinella_septempunctata_gca907165205v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Coccinella_septempunctata_GCA_907165185.1/Info/Index
 
 - species: Colias croceus
   image: Lepidoptera.png
   accession: GCA_905220415.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/genome/Colias_croceus-GCA_905220415.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/colias_croceus/GCA_905220415.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/geneset/2021_05/Colias_croceus-GCA_905220415.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1/genome/Colias_croceus-GCA_905220415.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/colias_croceus/GCA_905220415.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Colias_croceus/GCA_905220415.1
   rapid_link: https://rapid.ensembl.org/Colias_croceus_gca905220415v1/Info/Index
   alternate: https://rapid.ensembl.org/Colias_croceus_GCA_905220445.1/Info/Index
 
@@ -772,69 +772,69 @@
   image: Arthropods.png
   accession: GCA_914767935.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/genome/Coremacera_marginata-GCA_914767935.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/coremacera_marginata/GCA_914767935.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/geneset/2021_12/Coremacera_marginata-GCA_914767935.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1/genome/Coremacera_marginata-GCA_914767935.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/coremacera_marginata/GCA_914767935.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Coremacera_marginata/GCA_914767935.1
   rapid_link: https://rapid.ensembl.org/Coremacera_marginata_gca914767935v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/coremacera_marginata_GCA_914767935.1/coremacera_marginata_gca914767935v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/coremacera_marginata_GCA_914767935.1/coremacera_marginata_gca914767935v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Coremacera_marginata_GCA_914767655.1/Info/Index
 
 - species: Cosmia trapezina
   image: Lepidoptera.png
   accession: GCA_905163495.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/genome/Cosmia_trapezina-GCA_905163495.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cosmia_trapezina/GCA_905163495.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/geneset/2022_03/Cosmia_trapezina-GCA_905163495.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2/genome/Cosmia_trapezina-GCA_905163495.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cosmia_trapezina/GCA_905163495.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cosmia_trapezina/GCA_905163495.2
   rapid_link: https://rapid.ensembl.org/Cosmia_trapezina_gca905163495v2/Info/Index
 
 - species: Craniophora ligustri
   image: Lepidoptera.png
   accession: GCA_905163465.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/genome/Craniophora_ligustri-GCA_905163465.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/craniophora_ligustri/GCA_905163465.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/geneset/2021_11/Craniophora_ligustri-GCA_905163465.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1/genome/Craniophora_ligustri-GCA_905163465.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/craniophora_ligustri/GCA_905163465.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Craniophora_ligustri/GCA_905163465.1
   rapid_link: https://rapid.ensembl.org/Craniophora_ligustri_gca905163465v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/craniophora_ligustri_GCA_905163465.1/craniophora_ligustri_gca905163465v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/craniophora_ligustri_GCA_905163465.1/craniophora_ligustri_gca905163465v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Craniophora_ligustri_GCA_905163585.1/Info/Index
 
 - species: Criorhina berberina
   image: Arthropods.png
   accession: GCA_917880715.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/genome/Criorhina_berberina-GCA_917880715.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/criorhina_berberina/GCA_917880715.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/geneset/2022_03/Criorhina_berberina-GCA_917880715.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2/genome/Criorhina_berberina-GCA_917880715.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/criorhina_berberina/GCA_917880715.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Criorhina_berberina/GCA_917880715.2
   rapid_link: https://rapid.ensembl.org/Criorhina_berberina_gca917880715v2/Info/Index
 
 - species: Crocallis elinguaria
   image: Lepidoptera.png
   accession: GCA_907269065.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/genome/Crocallis_elinguaria-GCA_907269065.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/crocallis_elinguaria/GCA_907269065.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/geneset/2021_12/Crocallis_elinguaria-GCA_907269065.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1/genome/Crocallis_elinguaria-GCA_907269065.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/crocallis_elinguaria/GCA_907269065.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Crocallis_elinguaria/GCA_907269065.1
   rapid_link: https://rapid.ensembl.org/Crocallis_elinguaria_gca907269065v1/Info/Index
   alternate: https://rapid.ensembl.org/Crocallis_elinguaria_GCA_907269135.1/Info/Index
 
@@ -842,13 +842,13 @@
   image: Lepidoptera.png
   accession: GCA_905187585.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/genome/Cyaniris_semiargus-GCA_905187585.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyaniris_semiargus/GCA_905187585.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/geneset/2021_12/Cyaniris_semiargus-GCA_905187585.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1/genome/Cyaniris_semiargus-GCA_905187585.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyaniris_semiargus/GCA_905187585.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cyaniris_semiargus/GCA_905187585.1
   rapid_link: https://rapid.ensembl.org/Cyaniris_semiargus_gca905187585v1/Info/Index
   alternate: https://rapid.ensembl.org/Cyaniris_semiargus_GCA_905147265.1/Info/Index
 
@@ -856,67 +856,67 @@
   image: Lepidoptera.png
   accession: GCA_910591565.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/genome/Cydia_splendana-GCA_910591565.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cydia_splendana/GCA_910591565.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/geneset/2021_11/Cydia_splendana-GCA_910591565.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1/genome/Cydia_splendana-GCA_910591565.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cydia_splendana/GCA_910591565.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cydia_splendana/GCA_910591565.1
   rapid_link: https://rapid.ensembl.org/Cydia_splendana_gca910591565v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/cydia_splendana_GCA_910591565.1/cydia_splendana_gca910591565v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/cydia_splendana_GCA_910591565.1/cydia_splendana_gca910591565v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Cydia_splendana_GCA_910591525.1/Info/Index
 
 - species: Deilephila porcellus
   image: Lepidoptera.png
   accession: GCA_905220455.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/genome/Deilephila_porcellus-GCA_905220455.2-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/geneset/2022_03/Deilephila_porcellus-GCA_905220455.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2/genome/Deilephila_porcellus-GCA_905220455.2-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Deilephila_porcellus/GCA_905220455.2
   rapid_link: https://rapid.ensembl.org/Deilephila_porcellus_gca905220455v2/Info/Index
 
 - species: Dolichovespula media
   image: Arthropods.png
   accession: GCA_911387685.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/genome/Dolichovespula_media-GCA_911387685.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dolichovespula_media/GCA_911387685.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/geneset/2021_11/Dolichovespula_media-GCA_911387685.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1/genome/Dolichovespula_media-GCA_911387685.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dolichovespula_media/GCA_911387685.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_media/GCA_911387685.1
   rapid_link: https://rapid.ensembl.org/Dolichovespula_media_gca911387685v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/dolichovespula_media_GCA_911387685.1/dolichovespula_media_gca911387685v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/dolichovespula_media_GCA_911387685.1/dolichovespula_media_gca911387685v1_busco_short_summary.txt
 
 - species: Dolichovespula saxonica
   image: Arthropods.png
   accession: GCA_911387935.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/genome/Dolichovespula_saxonica-GCA_911387935.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dolichovespula_saxonica/GCA_911387935.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/geneset/2022_02/Dolichovespula_saxonica-GCA_911387935.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1/genome/Dolichovespula_saxonica-GCA_911387935.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dolichovespula_saxonica/GCA_911387935.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Dolichovespula_saxonica/GCA_911387935.1
   rapid_link: https://rapid.ensembl.org/Dolichovespula_saxonica_gca911387935v1/Info/Index
 
 - species: Dryobotodes eremita
   image: Lepidoptera.png
   accession: GCA_917490735.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/genome/Dryobotodes_eremita-GCA_917490735.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dryobotodes_eremita/GCA_917490735.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/geneset/2022_01/Dryobotodes_eremita-GCA_917490735.1-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1/genome/Dryobotodes_eremita-GCA_917490735.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/dryobotodes_eremita/GCA_917490735.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Dryobotodes_eremita/GCA_917490735.1
   rapid_link: https://rapid.ensembl.org/Dryobotodes_eremita_gca917490735v1/Info/Index
   alternate: https://rapid.ensembl.org/Dryobotodes_eremita_GCA_917490515.1/Info/Index
 
@@ -924,55 +924,55 @@
   image: Arthropods.png
   accession: GCA_910591665.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/genome/Ectemnius_continuus-GCA_910591665.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ectemnius_continuus/GCA_910591665.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/geneset/2021_11/Ectemnius_continuus-GCA_910591665.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1/genome/Ectemnius_continuus-GCA_910591665.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ectemnius_continuus/GCA_910591665.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_continuus/GCA_910591665.1
   rapid_link: https://rapid.ensembl.org/Ectemnius_continuus_gca910591665v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ectemnius_continuus_GCA_910591665.1/ectemnius_continuus_gca910591665v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ectemnius_continuus_GCA_910591665.1/ectemnius_continuus_gca910591665v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ectemnius_continuus_GCA_910591485.1/Info/Index
 
 - species: Ectemnius lituratus
   image: Arthropods.png
   accession: GCA_910593735.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/genome/Ectemnius_lituratus-GCA_910593735.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ectemnius_lituratus/GCA_910593735.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/geneset/2021_11/Ectemnius_lituratus-GCA_910593735.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1/genome/Ectemnius_lituratus-GCA_910593735.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ectemnius_lituratus/GCA_910593735.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.1
   rapid_link: https://rapid.ensembl.org/Ectemnius_lituratus_gca910593735v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ectemnius_lituratus_GCA_910593735.1/ectemnius_lituratus_gca910593735v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ectemnius_lituratus_GCA_910593735.1/ectemnius_lituratus_gca910593735v1_busco_short_summary.txt
 
 - species: Ectemnius lituratus
   image: Arthropods.png
   accession: GCA_910593735.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/genome/Ectemnius_lituratus-GCA_910593735.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ectemnius_lituratus/GCA_910593735.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/geneset/2022_03/Ectemnius_lituratus-GCA_910593735.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2/genome/Ectemnius_lituratus-GCA_910593735.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ectemnius_lituratus/GCA_910593735.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ectemnius_lituratus/GCA_910593735.2
   rapid_link: https://rapid.ensembl.org/Ectemnius_lituratus_gca910593735v2/Info/Index
 
 - species: Eilema depressum
   image: Lepidoptera.png
   accession: GCA_914767945.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/genome/Eilema_depressum-GCA_914767945.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eilema_depressum/GCA_914767945.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/geneset/2021_12/Eilema_depressum-GCA_914767945.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1/genome/Eilema_depressum-GCA_914767945.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eilema_depressum/GCA_914767945.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_depressum/GCA_914767945.1
   rapid_link: https://rapid.ensembl.org/Eilema_depressum_gca914767945v1/Info/Index
   alternate: https://rapid.ensembl.org/Eilema_depressum_GCA_914767765.1/Info/Index
 
@@ -980,13 +980,13 @@
   image: Lepidoptera.png
   accession: GCA_914829495.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/genome/Eilema_sororculum-GCA_914829495.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eilema_sororculum/GCA_914829495.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/geneset/2021_12/Eilema_sororculum-GCA_914829495.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1/genome/Eilema_sororculum-GCA_914829495.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eilema_sororculum/GCA_914829495.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eilema_sororculum/GCA_914829495.1
   rapid_link: https://rapid.ensembl.org/Eilema_sororculum_gca914829495v1/Info/Index
   alternate: https://rapid.ensembl.org/Eilema_sororculum_GCA_914829255.1/Info/Index
 
@@ -994,13 +994,13 @@
   image: Lepidoptera.png
   accession: GCA_916618145.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/genome/Emmelina_monodactyla-GCA_916618145.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/emmelina_monodactyla/GCA_916618145.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/geneset/2021_11/Emmelina_monodactyla-GCA_916618145.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1/genome/Emmelina_monodactyla-GCA_916618145.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/emmelina_monodactyla/GCA_916618145.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Emmelina_monodactyla/GCA_916618145.1
   rapid_link: https://rapid.ensembl.org/Emmelina_monodactyla_gca916618145v1/Info/Index
   alternate: https://rapid.ensembl.org/Emmelina_monodactyla_GCA_916618085.1/Info/Index
 
@@ -1008,70 +1008,70 @@
   image: Lepidoptera.png
   accession: GCA_905163395.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/genome/Endotricha_flammealis-GCA_905163395.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/endotricha_flammealis/GCA_905163395.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/geneset/2022_03/Endotricha_flammealis-GCA_905163395.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2/genome/Endotricha_flammealis-GCA_905163395.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/endotricha_flammealis/GCA_905163395.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Endotricha_flammealis/GCA_905163395.2
   rapid_link: https://rapid.ensembl.org/Endotricha_flammealis_gca905163395v2/Info/Index
 
 - species: Ennomos fuscantarius
   image: Lepidoptera.png
   accession: GCA_905220475.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/genome/Ennomos_fuscantarius-GCA_905220475.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ennomos_fuscantarius/GCA_905220475.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/geneset/2021_11/Ennomos_fuscantarius-GCA_905220475.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1/genome/Ennomos_fuscantarius-GCA_905220475.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ennomos_fuscantarius/GCA_905220475.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.1
   rapid_link: https://rapid.ensembl.org/Ennomos_fuscantarius_gca905220475v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_fuscantarius_GCA_905220475.1/ennomos_fuscantarius_gca905220475v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_fuscantarius_GCA_905220475.1/ennomos_fuscantarius_gca905220475v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ennomos_fuscantarius_GCA_905220485.1/Info/Index
 
 - species: Ennomos fuscantarius
   image: Lepidoptera.png
   accession: GCA_905220475.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/genome/Ennomos_fuscantarius-GCA_905220475.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ennomos_fuscantarius/GCA_905220475.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/geneset/2022_03/Ennomos_fuscantarius-GCA_905220475.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2/genome/Ennomos_fuscantarius-GCA_905220475.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ennomos_fuscantarius/GCA_905220475.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_fuscantarius/GCA_905220475.2
   rapid_link: https://rapid.ensembl.org/Ennomos_fuscantarius_gca905220475v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_fuscantarius_GCA_905220475.2/ennomos_fuscantarius_gca905220475v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_fuscantarius_GCA_905220475.2/ennomos_fuscantarius_gca905220475v2_busco_short_summary.txt
 
 - species: Ennomos quercinarius
   image: Lepidoptera.png
   accession: GCA_910589525.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/genome/Ennomos_quercinarius-GCA_910589525.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ennomos_quercinarius/GCA_910589525.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/geneset/2021_11/Ennomos_quercinarius-GCA_910589525.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1/genome/Ennomos_quercinarius-GCA_910589525.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ennomos_quercinarius/GCA_910589525.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ennomos_quercinarius/GCA_910589525.1
   rapid_link: https://rapid.ensembl.org/Ennomos_quercinarius_gca910589525v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_quercinarius_GCA_910589525.1/ennomos_quercinarius_gca910589525v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ennomos_quercinarius_GCA_910589525.1/ennomos_quercinarius_gca910589525v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ennomos_quercinarius_GCA_910589225.1/Info/Index
 
 - species: Erannis defoliaria
   image: Lepidoptera.png
   accession: GCA_905404285.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/genome/Erannis_defoliaria-GCA_905404285.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erannis_defoliaria/GCA_905404285.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/geneset/2021_12/Erannis_defoliaria-GCA_905404285.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1/genome/Erannis_defoliaria-GCA_905404285.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erannis_defoliaria/GCA_905404285.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Erannis_defoliaria/GCA_905404285.1
   rapid_link: https://rapid.ensembl.org/Erannis_defoliaria_gca905404285v1/Info/Index
   alternate: https://rapid.ensembl.org/Erannis_defoliaria_GCA_905404195.1/Info/Index
 
@@ -1079,13 +1079,13 @@
   image: Lepidoptera.png
   accession: GCA_917051295.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/genome/Erebia_ligea-GCA_917051295.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erebia_ligea/GCA_917051295.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/geneset/2022_03/Erebia_ligea-GCA_917051295.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2/genome/Erebia_ligea-GCA_917051295.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erebia_ligea/GCA_917051295.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Erebia_ligea/GCA_917051295.2
   rapid_link: https://rapid.ensembl.org/Erebia_ligea_gca917051295v2/Info/Index
   alternate: https://rapid.ensembl.org/Erebia_ligea_GCA_917050995.2/Info/Index
 
@@ -1093,71 +1093,71 @@
   image: Arthropods.png
   accession: GCA_916610145.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/genome/Eristalis_arbustorum-GCA_916610145.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_arbustorum/GCA_916610145.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/geneset/2021_12/Eristalis_arbustorum-GCA_916610145.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1/genome/Eristalis_arbustorum-GCA_916610145.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_arbustorum/GCA_916610145.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_arbustorum/GCA_916610145.1
   rapid_link: https://rapid.ensembl.org/Eristalis_arbustorum_gca916610145v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_arbustorum_GCA_916610145.1/eristalis_arbustorum_gca916610145v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_arbustorum_GCA_916610145.1/eristalis_arbustorum_gca916610145v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Eristalis_arbustorum_GCA_916610155.1/Info/Index
 
 - species: Eristalis pertinax
   image: Arthropods.png
   accession: GCA_907269125.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/genome/Eristalis_pertinax-GCA_907269125.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_pertinax/GCA_907269125.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/geneset/2021_12/Eristalis_pertinax-GCA_907269125.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1/genome/Eristalis_pertinax-GCA_907269125.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_pertinax/GCA_907269125.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_pertinax/GCA_907269125.1
   rapid_link: https://rapid.ensembl.org/Eristalis_pertinax_gca907269125v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_pertinax_GCA_907269125.1/eristalis_pertinax_gca907269125v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_pertinax_GCA_907269125.1/eristalis_pertinax_gca907269125v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Eristalis_pertinax_GCA_907269085.1/Info/Index
 
 - species: Eristalis tenax
   image: Arthropods.png
   accession: GCA_905231855.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/genome/Eristalis_tenax-GCA_905231855.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_tenax/GCA_905231855.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/geneset/2021_12/Eristalis_tenax-GCA_905231855.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1/genome/Eristalis_tenax-GCA_905231855.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_tenax/GCA_905231855.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.1
   rapid_link: https://rapid.ensembl.org/Eristalis_tenax_gca905231855v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_tenax_GCA_905231855.1/eristalis_tenax_gca905231855v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eristalis_tenax_GCA_905231855.1/eristalis_tenax_gca905231855v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Eristalis_tenax_GCA_905231845.1/Info/Index
 
 - species: Eristalis tenax
   image: Arthropods.png
   accession: GCA_905231855.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/genome/Eristalis_tenax-GCA_905231855.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_tenax/GCA_905231855.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/geneset/2022_03/Eristalis_tenax-GCA_905231855.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2/genome/Eristalis_tenax-GCA_905231855.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eristalis_tenax/GCA_905231855.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eristalis_tenax/GCA_905231855.2
   rapid_link: https://rapid.ensembl.org/Eristalis_tenax_gca905231855v2/Info/Index
 
 - species: Erynnis tages
   image: Lepidoptera.png
   accession: GCA_905147235.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/genome/Erynnis_tages-GCA_905147235.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erynnis_tages/GCA_905147235.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/geneset/2021_11/Erynnis_tages-GCA_905147235.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1/genome/Erynnis_tages-GCA_905147235.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erynnis_tages/GCA_905147235.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Erynnis_tages/GCA_905147235.1
   rapid_link: https://rapid.ensembl.org/Erynnis_tages_gca905147235v1/Info/Index
   alternate: https://rapid.ensembl.org/Erynnis_tages_GCA_905147245.1/Info/Index
 
@@ -1165,69 +1165,69 @@
   image: Lepidoptera.png
   accession: GCA_918843925.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/genome/Eulithis_prunata-GCA_918843925.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eulithis_prunata/GCA_918843925.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/geneset/2022_01/Eulithis_prunata-GCA_918843925.1-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1/genome/Eulithis_prunata-GCA_918843925.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eulithis_prunata/GCA_918843925.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eulithis_prunata/GCA_918843925.1
   rapid_link: https://rapid.ensembl.org/Eulithis_prunata_gca918843925v1/Info/Index
 
 - species: Eupeodes latifasciatus
   image: Arthropods.png
   accession: GCA_920104205.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/genome/Eupeodes_latifasciatus-GCA_920104205.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eupeodes_latifasciatus/GCA_920104205.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/geneset/2021_12/Eupeodes_latifasciatus-GCA_920104205.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1/genome/Eupeodes_latifasciatus-GCA_920104205.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eupeodes_latifasciatus/GCA_920104205.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eupeodes_latifasciatus/GCA_920104205.1
   rapid_link: https://rapid.ensembl.org/Eupeodes_latifasciatus_gca920104205v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eupeodes_latifasciatus_GCA_920104205.1/eupeodes_latifasciatus_gca920104205v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/eupeodes_latifasciatus_GCA_920104205.1/eupeodes_latifasciatus_gca920104205v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Eupeodes_latifasciatus_GCA_920104105.1/Info/Index
 
 - species: Euproctis similis
   image: Lepidoptera.png
   accession: GCA_905147225.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/genome/Euproctis_similis-GCA_905147225.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/euproctis_similis/GCA_905147225.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/geneset/2021_11/Euproctis_similis-GCA_905147225.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1/genome/Euproctis_similis-GCA_905147225.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/euproctis_similis/GCA_905147225.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.1
   rapid_link: https://rapid.ensembl.org/Euproctis_similis_gca905147225v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/euproctis_similis_GCA_905147225.1/euproctis_similis_gca905147225v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/euproctis_similis_GCA_905147225.1/euproctis_similis_gca905147225v1_busco_short_summary.txt
 
 - species: Euproctis similis
   image: Lepidoptera.png
   accession: GCA_905147225.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/genome/Euproctis_similis-GCA_905147225.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/euproctis_similis/GCA_905147225.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/geneset/2022_03/Euproctis_similis-GCA_905147225.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2/genome/Euproctis_similis-GCA_905147225.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/euproctis_similis/GCA_905147225.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Euproctis_similis/GCA_905147225.2
   rapid_link: https://rapid.ensembl.org/Euproctis_similis_gca905147225v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/euproctis_similis_GCA_905147225.2/euproctis_similis_gca905147225v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/euproctis_similis_GCA_905147225.2/euproctis_similis_gca905147225v2_busco_short_summary.txt
 
 - species: Eupsilia transversa
   image: Lepidoptera.png
   accession: GCA_914767815.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/genome/Eupsilia_transversa-GCA_914767815.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eupsilia_transversa/GCA_914767815.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/geneset/2021_12/Eupsilia_transversa-GCA_914767815.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1/genome/Eupsilia_transversa-GCA_914767815.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/eupsilia_transversa/GCA_914767815.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Eupsilia_transversa/GCA_914767815.1
   rapid_link: https://rapid.ensembl.org/Eupsilia_transversa_gca914767815v1/Info/Index
   alternate: https://rapid.ensembl.org/Eupsilia_transversa_GCA_914767805.1/Info/Index
 
@@ -1235,13 +1235,13 @@
   image: Lepidoptera.png
   accession: GCA_905404265.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/genome/Fabriciana_adippe-GCA_905404265.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/fabriciana_adippe/GCA_905404265.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/geneset/2021_11/Fabriciana_adippe-GCA_905404265.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1/genome/Fabriciana_adippe-GCA_905404265.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/fabriciana_adippe/GCA_905404265.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Fabriciana_adippe/GCA_905404265.1
   rapid_link: https://rapid.ensembl.org/Fabriciana_adippe_gca905404265v1/Info/Index
   alternate: https://rapid.ensembl.org/Fabriciana_adippe_GCA_905404255.1/Info/Index
 
@@ -1249,26 +1249,26 @@
   image: Lepidoptera.png
   accession: GCA_911728495.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/genome/Furcula_furcula-GCA_911728495.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/furcula_furcula/GCA_911728495.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/geneset/2021_12/Furcula_furcula-GCA_911728495.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1/genome/Furcula_furcula-GCA_911728495.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/furcula_furcula/GCA_911728495.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Furcula_furcula/GCA_911728495.1
   rapid_link: https://rapid.ensembl.org/Furcula_furcula_gca911728495v1/Info/Index
 
 - species: Glaucopsyche alexis
   image: Lepidoptera.png
   accession: GCA_905404095.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/genome/Glaucopsyche_alexis-GCA_905404095.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/glaucopsyche_alexis/GCA_905404095.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/geneset/2021_12/Glaucopsyche_alexis-GCA_905404095.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1/genome/Glaucopsyche_alexis-GCA_905404095.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/glaucopsyche_alexis/GCA_905404095.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Glaucopsyche_alexis/GCA_905404095.1
   rapid_link: https://rapid.ensembl.org/Glaucopsyche_alexis_gca905404095v1/Info/Index
   alternate: https://rapid.ensembl.org/Glaucopsyche_alexis_GCA_905404225.1/Info/Index
 
@@ -1276,13 +1276,13 @@
   image: Lepidoptera.png
   accession: GCA_916610205.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/genome/Griposia_aprilina-GCA_916610205.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/griposia_aprilina/GCA_916610205.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/geneset/2021_12/Griposia_aprilina-GCA_916610205.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1/genome/Griposia_aprilina-GCA_916610205.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/griposia_aprilina/GCA_916610205.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Griposia_aprilina/GCA_916610205.1
   rapid_link: https://rapid.ensembl.org/Griposia_aprilina_gca916610205v1/Info/Index
   alternate: https://rapid.ensembl.org/Griposia_aprilina_GCA_916610245.1/Info/Index
 
@@ -1290,28 +1290,28 @@
   image: Arthropods.png
   accession: GCA_916610165.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/genome/Gymnosoma_rotundatum-GCA_916610165.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnosoma_rotundatum/GCA_916610165.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/geneset/2021_12/Gymnosoma_rotundatum-GCA_916610165.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1/genome/Gymnosoma_rotundatum-GCA_916610165.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnosoma_rotundatum/GCA_916610165.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.1
   rapid_link: https://rapid.ensembl.org/Gymnosoma_rotundatum_gca916610165v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/gymnosoma_rotundatum_GCA_916610165.1/gymnosoma_rotundatum_gca916610165v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/gymnosoma_rotundatum_GCA_916610165.1/gymnosoma_rotundatum_gca916610165v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Gymnosoma_rotundatum_GCA_916610175.1/Info/Index
 
 - species: Gymnosoma rotundatum
   image: Arthropods.png
   accession: GCA_916610165.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/genome/Gymnosoma_rotundatum-GCA_916610165.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnosoma_rotundatum/GCA_916610165.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/geneset/2022_03/Gymnosoma_rotundatum-GCA_916610165.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2/genome/Gymnosoma_rotundatum-GCA_916610165.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnosoma_rotundatum/GCA_916610165.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gymnosoma_rotundatum/GCA_916610165.2
   rapid_link: https://rapid.ensembl.org/Gymnosoma_rotundatum_gca916610165v2/Info/Index
   alternate: https://rapid.ensembl.org/Gymnosoma_rotundatum_GCA_916610175.2/Info/Index
 
@@ -1319,13 +1319,13 @@
   image: Lepidoptera.png
   accession: GCA_907165245.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/genome/Habrosyne_pyritoides-GCA_907165245.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/habrosyne_pyritoides/GCA_907165245.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/geneset/2021_12/Habrosyne_pyritoides-GCA_907165245.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1/genome/Habrosyne_pyritoides-GCA_907165245.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/habrosyne_pyritoides/GCA_907165245.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Habrosyne_pyritoides/GCA_907165245.1
   rapid_link: https://rapid.ensembl.org/Habrosyne_pyritoides_gca907165245v1/Info/Index
   alternate: https://rapid.ensembl.org/Habrosyne_pyritoides_GCA_907165225.1/Info/Index
 
@@ -1333,71 +1333,71 @@
   image: Lepidoptera.png
   accession: GCA_905332915.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/genome/Hecatera_dysodea-GCA_905332915.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hecatera_dysodea/GCA_905332915.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/geneset/2021_11/Hecatera_dysodea-GCA_905332915.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1/genome/Hecatera_dysodea-GCA_905332915.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hecatera_dysodea/GCA_905332915.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.1
   rapid_link: https://rapid.ensembl.org/Hecatera_dysodea_gca905332915v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hecatera_dysodea_GCA_905332915.1/hecatera_dysodea_gca905332915v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hecatera_dysodea_GCA_905332915.1/hecatera_dysodea_gca905332915v1_busco_short_summary.txt
 
 - species: Hecatera dysodea
   image: Lepidoptera.png
   accession: GCA_905332915.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/genome/Hecatera_dysodea-GCA_905332915.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hecatera_dysodea/GCA_905332915.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/geneset/2022_03/Hecatera_dysodea-GCA_905332915.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2/genome/Hecatera_dysodea-GCA_905332915.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hecatera_dysodea/GCA_905332915.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hecatera_dysodea/GCA_905332915.2
   rapid_link: https://rapid.ensembl.org/Hecatera_dysodea_gca905332915v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hecatera_dysodea_GCA_905332915.2/hecatera_dysodea_gca905332915v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hecatera_dysodea_GCA_905332915.2/hecatera_dysodea_gca905332915v2_busco_short_summary.txt
 
 - species: Hedya salicella
   image: Lepidoptera.png
   accession: GCA_905404275.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/genome/Hedya_salicella-GCA_905404275.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hedya_salicella/GCA_905404275.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/geneset/2021_11/Hedya_salicella-GCA_905404275.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1/genome/Hedya_salicella-GCA_905404275.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hedya_salicella/GCA_905404275.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hedya_salicella/GCA_905404275.1
   rapid_link: https://rapid.ensembl.org/Hedya_salicella_gca905404275v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hedya_salicella_GCA_905404275.1/hedya_salicella_gca905404275v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hedya_salicella_GCA_905404275.1/hedya_salicella_gca905404275v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Hedya_salicella_GCA_905404235.1/Info/Index
 
 - species: Hemaris fuciformis
   image: Lepidoptera.png
   accession: GCA_907164795.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/genome/Hemaris_fuciformis-GCA_907164795.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hemaris_fuciformis/GCA_907164795.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/geneset/2021_11/Hemaris_fuciformis-GCA_907164795.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1/genome/Hemaris_fuciformis-GCA_907164795.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hemaris_fuciformis/GCA_907164795.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hemaris_fuciformis/GCA_907164795.1
   rapid_link: https://rapid.ensembl.org/Hemaris_fuciformis_gca907164795v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hemaris_fuciformis_GCA_907164795.1/hemaris_fuciformis_gca907164795v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hemaris_fuciformis_GCA_907164795.1/hemaris_fuciformis_gca907164795v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Hemaris_fuciformis_GCA_907164865.1/Info/Index
 
 - species: Hesperia comma
   image: Lepidoptera.png
   accession: GCA_905404135.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/genome/Hesperia_comma-GCA_905404135.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hesperia_comma/GCA_905404135.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/geneset/2021_12/Hesperia_comma-GCA_905404135.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1/genome/Hesperia_comma-GCA_905404135.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hesperia_comma/GCA_905404135.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hesperia_comma/GCA_905404135.1
   rapid_link: https://rapid.ensembl.org/Hesperia_comma_gca905404135v1/Info/Index
   alternate: https://rapid.ensembl.org/Hesperia_comma_GCA_905404245.1/Info/Index
 
@@ -1405,13 +1405,13 @@
   image: Lepidoptera.png
   accession: GCA_914767645.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/genome/Hydraecia_micacea-GCA_914767645.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hydraecia_micacea/GCA_914767645.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/geneset/2021_12/Hydraecia_micacea-GCA_914767645.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1/genome/Hydraecia_micacea-GCA_914767645.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hydraecia_micacea/GCA_914767645.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hydraecia_micacea/GCA_914767645.1
   rapid_link: https://rapid.ensembl.org/Hydraecia_micacea_gca914767645v1/Info/Index
   alternate: https://rapid.ensembl.org/Hydraecia_micacea_GCA_914767565.1/Info/Index
 
@@ -1419,13 +1419,13 @@
   image: Lepidoptera.png
   accession: GCA_912999785.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/genome/Hydriomena_furcata-GCA_912999785.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hydriomena_furcata/GCA_912999785.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/geneset/2021_12/Hydriomena_furcata-GCA_912999785.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1/genome/Hydriomena_furcata-GCA_912999785.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hydriomena_furcata/GCA_912999785.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hydriomena_furcata/GCA_912999785.1
   rapid_link: https://rapid.ensembl.org/Hydriomena_furcata_gca912999785v1/Info/Index
   alternate: https://rapid.ensembl.org/Hydriomena_furcata_GCA_912999755.1/Info/Index
 
@@ -1433,13 +1433,13 @@
   image: Lepidoptera.png
   accession: GCA_905147375.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/genome/Hylaea_fasciaria-GCA_905147375.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hylaea_fasciaria/GCA_905147375.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/geneset/2022_03/Hylaea_fasciaria-GCA_905147375.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1/genome/Hylaea_fasciaria-GCA_905147375.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hylaea_fasciaria/GCA_905147375.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hylaea_fasciaria/GCA_905147375.1
   rapid_link: https://rapid.ensembl.org/Hylaea_fasciaria_gca905147375v1/Info/Index
   alternate: https://rapid.ensembl.org/Hylaea_fasciaria_GCA_905147295.1/Info/Index
 
@@ -1447,58 +1447,58 @@
   image: Lepidoptera.png
   accession: GCA_905147285.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/genome/Hypena_proboscidalis-GCA_905147285.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hypena_proboscidalis/GCA_905147285.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/geneset/2021_11/Hypena_proboscidalis-GCA_905147285.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1/genome/Hypena_proboscidalis-GCA_905147285.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hypena_proboscidalis/GCA_905147285.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hypena_proboscidalis/GCA_905147285.1
   rapid_link: https://rapid.ensembl.org/Hypena_proboscidalis_gca905147285v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hypena_proboscidalis_GCA_905147285.1/hypena_proboscidalis_gca905147285v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/hypena_proboscidalis_GCA_905147285.1/hypena_proboscidalis_gca905147285v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Hypena_proboscidalis_GCA_905147305.1/Info/Index
 
 - species: Ichneumon xanthorius
   image: Arthropods.png
   accession: GCA_917499995.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/genome/Ichneumon_xanthorius-GCA_917499995.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ichneumon_xanthorius/GCA_917499995.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/geneset/2021_11/Ichneumon_xanthorius-GCA_917499995.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1/genome/Ichneumon_xanthorius-GCA_917499995.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ichneumon_xanthorius/GCA_917499995.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ichneumon_xanthorius/GCA_917499995.1
   rapid_link: https://rapid.ensembl.org/Ichneumon_xanthorius_gca917499995v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ichneumon_xanthorius_GCA_917499995.1/ichneumon_xanthorius_gca917499995v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ichneumon_xanthorius_GCA_917499995.1/ichneumon_xanthorius_gca917499995v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ichneumon_xanthorius_GCA_917498535.1/Info/Index
 
 - species: Idaea aversata
   image: Lepidoptera.png
   accession: GCA_907269075.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/genome/Idaea_aversata-GCA_907269075.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/idaea_aversata/GCA_907269075.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/geneset/2021_11/Idaea_aversata-GCA_907269075.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1/genome/Idaea_aversata-GCA_907269075.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/idaea_aversata/GCA_907269075.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Idaea_aversata/GCA_907269075.1
   rapid_link: https://rapid.ensembl.org/Idaea_aversata_gca907269075v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/idaea_aversata_GCA_907269075.1/idaea_aversata_gca907269075v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/idaea_aversata_GCA_907269075.1/idaea_aversata_gca907269075v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Idaea_aversata_GCA_907269045.1/Info/Index
 
 - species: Inachis io
   image: Lepidoptera.png
   accession: GCA_905147045.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/genome/Inachis_io-GCA_905147045.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/inachis_io/GCA_905147045.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/geneset/2021_05/Inachis_io-GCA_905147045.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1/genome/Inachis_io-GCA_905147045.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/inachis_io/GCA_905147045.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Inachis_io/GCA_905147045.1
   rapid_link: https://rapid.ensembl.org/Inachis_io_gca905147045v1/Info/Index
   alternate: https://rapid.ensembl.org/Inachis_io_GCA_905147125.1/Info/Index
 
@@ -1506,13 +1506,13 @@
   image: Lepidoptera.png
   accession: GCA_905220505.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/genome/Laothoe_populi-GCA_905220505.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/laothoe_populi/GCA_905220505.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/geneset/2021_12/Laothoe_populi-GCA_905220505.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1/genome/Laothoe_populi-GCA_905220505.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/laothoe_populi/GCA_905220505.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Laothoe_populi/GCA_905220505.1
   rapid_link: https://rapid.ensembl.org/Laothoe_populi_gca905220505v1/Info/Index
   alternate: https://rapid.ensembl.org/Laothoe_populi_GCA_905220495.1/Info/Index
 
@@ -1520,54 +1520,54 @@
   image: Arthropods.png
   accession: GCA_916610255.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/genome/Lasioglossum_lativentre-GCA_916610255.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lasioglossum_lativentre/GCA_916610255.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/geneset/2022_02/Lasioglossum_lativentre-GCA_916610255.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1/genome/Lasioglossum_lativentre-GCA_916610255.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lasioglossum_lativentre/GCA_916610255.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_lativentre/GCA_916610255.1
   rapid_link: https://rapid.ensembl.org/Lasioglossum_lativentre_gca916610255v1/Info/Index
 
 - species: Lasioglossum morio
   image: Arthropods.png
   accession: GCA_916610235.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/genome/Lasioglossum_morio-GCA_916610235.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lasioglossum_morio/GCA_916610235.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/geneset/2022_03/Lasioglossum_morio-GCA_916610235.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2/genome/Lasioglossum_morio-GCA_916610235.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lasioglossum_morio/GCA_916610235.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lasioglossum_morio/GCA_916610235.2
   rapid_link: https://rapid.ensembl.org/Lasioglossum_morio_gca916610235v2/Info/Index
 
 - species: Laspeyria flexula
   image: Lepidoptera.png
   accession: GCA_905147015.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/genome/Laspeyria_flexula-GCA_905147015.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/laspeyria_flexula/GCA_905147015.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/geneset/2021_11/Laspeyria_flexula-GCA_905147015.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1/genome/Laspeyria_flexula-GCA_905147015.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/laspeyria_flexula/GCA_905147015.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Laspeyria_flexula/GCA_905147015.1
   rapid_link: https://rapid.ensembl.org/Laspeyria_flexula_gca905147015v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/laspeyria_flexula_GCA_905147015.1/laspeyria_flexula_gca905147015v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/laspeyria_flexula_GCA_905147015.1/laspeyria_flexula_gca905147015v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Laspeyria_flexula_GCA_905147035.1/Info/Index
 
 - species: Leptidea sinapis
   image: Lepidoptera.png
   accession: GCA_905404315.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/genome/Leptidea_sinapis-GCA_905404315.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/leptidea_sinapis/GCA_905404315.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/geneset/2021_11/Leptidea_sinapis-GCA_905404315.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1/genome/Leptidea_sinapis-GCA_905404315.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/leptidea_sinapis/GCA_905404315.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Leptidea_sinapis/GCA_905404315.1
   rapid_link: https://rapid.ensembl.org/Leptidea_sinapis_gca905404315v1/Info/Index
   alternate: https://rapid.ensembl.org/Leptidea_sinapis_GCA_905404105.1/Info/Index
 
@@ -1575,27 +1575,27 @@
   image: Lepidoptera.png
   accession: GCA_905147385.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/genome/Limenitis_camilla-GCA_905147385.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/limenitis_camilla/GCA_905147385.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/geneset/2021_11/Limenitis_camilla-GCA_905147385.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1/genome/Limenitis_camilla-GCA_905147385.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/limenitis_camilla/GCA_905147385.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Limenitis_camilla/GCA_905147385.1
   rapid_link: https://rapid.ensembl.org/Limenitis_camilla_gca905147385v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/limenitis_camilla_GCA_905147385.1/limenitis_camilla_gca905147385v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/limenitis_camilla_GCA_905147385.1/limenitis_camilla_gca905147385v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Limenitis_camilla_GCA_905147315.1/Info/Index
 
 - species: Lineus longissimus
   image: Metazoa.png
   accession: GCA_910592395.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/genome/Lineus_longissimus-GCA_910592395.2-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/geneset/2022_03/Lineus_longissimus-GCA_910592395.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2/genome/Lineus_longissimus-GCA_910592395.2-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lineus_longissimus/GCA_910592395.2
   rapid_link: https://rapid.ensembl.org/Lineus_longissimus_gca910592395v2/Info/Index
   alternate: https://rapid.ensembl.org/Lineus_longissimus_GCA_910592375.2/Info/Index
 
@@ -1603,13 +1603,13 @@
   image: Lepidoptera.png
   accession: GCA_905333005.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/genome/Lycaena_phlaeas-GCA_905333005.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lycaena_phlaeas/GCA_905333005.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/geneset/2021_06/Lycaena_phlaeas-GCA_905333005.1-2021_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1/genome/Lycaena_phlaeas-GCA_905333005.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lycaena_phlaeas/GCA_905333005.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lycaena_phlaeas/GCA_905333005.1
   rapid_link: https://rapid.ensembl.org/Lycaena_phlaeas_gca905333005v1/Info/Index
   alternate: https://rapid.ensembl.org/Lycaena_phlaeas_GCA_905333065.1/Info/Index
 
@@ -1617,71 +1617,71 @@
   image: Lepidoptera.png
   accession: GCA_905163515.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/genome/Lymantria_monacha-GCA_905163515.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lymantria_monacha/GCA_905163515.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/geneset/2022_03/Lymantria_monacha-GCA_905163515.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2/genome/Lymantria_monacha-GCA_905163515.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lymantria_monacha/GCA_905163515.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lymantria_monacha/GCA_905163515.2
   rapid_link: https://rapid.ensembl.org/Lymantria_monacha_gca905163515v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lymantria_monacha_GCA_905163515.2/lymantria_monacha_gca905163515v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lymantria_monacha_GCA_905163515.2/lymantria_monacha_gca905163515v2_busco_short_summary.txt
 
 - species: Lysandra bellargus
   image: Lepidoptera.png
   accession: GCA_905333045.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/genome/Lysandra_bellargus-GCA_905333045.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lysandra_bellargus/GCA_905333045.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/geneset/2021_11/Lysandra_bellargus-GCA_905333045.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1/genome/Lysandra_bellargus-GCA_905333045.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lysandra_bellargus/GCA_905333045.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_bellargus/GCA_905333045.1
   rapid_link: https://rapid.ensembl.org/Lysandra_bellargus_gca905333045v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lysandra_bellargus_GCA_905333045.1/lysandra_bellargus_gca905333045v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lysandra_bellargus_GCA_905333045.1/lysandra_bellargus_gca905333045v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Lysandra_bellargus_GCA_905332955.1/Info/Index
 
 - species: Lysandra coridon
   image: Lepidoptera.png
   accession: GCA_905220515.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/genome/Lysandra_coridon-GCA_905220515.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lysandra_coridon/GCA_905220515.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/geneset/2021_11/Lysandra_coridon-GCA_905220515.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1/genome/Lysandra_coridon-GCA_905220515.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lysandra_coridon/GCA_905220515.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lysandra_coridon/GCA_905220515.1
   rapid_link: https://rapid.ensembl.org/Lysandra_coridon_gca905220515v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lysandra_coridon_GCA_905220515.1/lysandra_coridon_gca905220515v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/lysandra_coridon_GCA_905220515.1/lysandra_coridon_gca905220515v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Lysandra_coridon_GCA_905220525.1/Info/Index
 
 - species: Macropis europaea
   image: Arthropods.png
   accession: GCA_916610135.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/genome/Macropis_europaea-GCA_916610135.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/macropis_europaea/GCA_916610135.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/geneset/2021_11/Macropis_europaea-GCA_916610135.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1/genome/Macropis_europaea-GCA_916610135.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/macropis_europaea/GCA_916610135.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Macropis_europaea/GCA_916610135.1
   rapid_link: https://rapid.ensembl.org/Macropis_europaea_gca916610135v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/macropis_europaea_GCA_916610135.1/macropis_europaea_gca916610135v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/macropis_europaea_GCA_916610135.1/macropis_europaea_gca916610135v1_busco_short_summary.txt
 
 - species: Malachius bipustulatus
   image: Arthropods.png
   accession: GCA_910589415.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/genome/Malachius_bipustulatus-GCA_910589415.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/malachius_bipustulatus/GCA_910589415.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/geneset/2022_02/Malachius_bipustulatus-GCA_910589415.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1/genome/Malachius_bipustulatus-GCA_910589415.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/malachius_bipustulatus/GCA_910589415.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Malachius_bipustulatus/GCA_910589415.1
   rapid_link: https://rapid.ensembl.org/Malachius_bipustulatus_gca910589415v1/Info/Index
   alternate: https://rapid.ensembl.org/Malachius_bipustulatus_GCA_910589365.1/Info/Index
 
@@ -1689,41 +1689,41 @@
   image: Lepidoptera.png
   accession: GCA_905163435.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/genome/Mamestra_brassicae-GCA_905163435.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mamestra_brassicae/GCA_905163435.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/geneset/2021_11/Mamestra_brassicae-GCA_905163435.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1/genome/Mamestra_brassicae-GCA_905163435.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mamestra_brassicae/GCA_905163435.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mamestra_brassicae/GCA_905163435.1
   rapid_link: https://rapid.ensembl.org/Mamestra_brassicae_gca905163435v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mamestra_brassicae_GCA_905163435.1/mamestra_brassicae_gca905163435v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mamestra_brassicae_GCA_905163435.1/mamestra_brassicae_gca905163435v1_busco_short_summary.txt
 
 - species: Maniola hyperantus
   image: Lepidoptera.png
   accession: GCA_902806685.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/genome/Maniola_hyperantus-GCA_902806685.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/maniola_hyperantus/GCA_902806685.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/geneset/2021_11/Maniola_hyperantus-GCA_902806685.2-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2/genome/Maniola_hyperantus-GCA_902806685.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/maniola_hyperantus/GCA_902806685.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_hyperantus/GCA_902806685.2
   rapid_link: https://rapid.ensembl.org/Maniola_hyperantus_gca902806685v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/maniola_hyperantus_GCA_902806685.2/maniola_hyperantus_gca902806685v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/maniola_hyperantus_GCA_902806685.2/maniola_hyperantus_gca902806685v2_busco_short_summary.txt
 
 - species: Maniola jurtina
   image: Lepidoptera.png
   accession: GCA_905333055.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/genome/Maniola_jurtina-GCA_905333055.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/maniola_jurtina/GCA_905333055.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/geneset/2021_06/Maniola_jurtina-GCA_905333055.1-2021_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1/genome/Maniola_jurtina-GCA_905333055.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/maniola_jurtina/GCA_905333055.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Maniola_jurtina/GCA_905333055.1
   rapid_link: https://rapid.ensembl.org/Maniola_jurtina_gca905333055v1/Info/Index
   alternate: https://rapid.ensembl.org/Maniola_jurtina_GCA_905333105.1/Info/Index
 
@@ -1731,43 +1731,43 @@
   image: Lepidoptera.png
   accession: GCA_920104075.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/genome/Melanargia_galathea-GCA_920104075.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melanargia_galathea/GCA_920104075.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/geneset/2022_01/Melanargia_galathea-GCA_920104075.1-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1/genome/Melanargia_galathea-GCA_920104075.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melanargia_galathea/GCA_920104075.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Melanargia_galathea/GCA_920104075.1
   rapid_link: https://rapid.ensembl.org/Melanargia_galathea_gca920104075v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/melanargia_galathea_GCA_920104075.1/melanargia_galathea_gca920104075v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/melanargia_galathea_GCA_920104075.1/melanargia_galathea_gca920104075v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Melanargia_galathea_GCA_920103875.1/Info/Index
 
 - species: Melanostoma mellinum
   image: Arthropods.png
   accession: GCA_914767635.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/genome/Melanostoma_mellinum-GCA_914767635.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melanostoma_mellinum/GCA_914767635.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/geneset/2021_12/Melanostoma_mellinum-GCA_914767635.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1/genome/Melanostoma_mellinum-GCA_914767635.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melanostoma_mellinum/GCA_914767635.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Melanostoma_mellinum/GCA_914767635.1
   rapid_link: https://rapid.ensembl.org/Melanostoma_mellinum_gca914767635v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/melanostoma_mellinum_GCA_914767635.1/melanostoma_mellinum_gca914767635v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/melanostoma_mellinum_GCA_914767635.1/melanostoma_mellinum_gca914767635v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Melanostoma_mellinum_GCA_914767615.1/Info/Index
 
 - species: Melitaea cinxia
   image: Lepidoptera.png
   accession: GCA_905220565.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/genome/Melitaea_cinxia-GCA_905220565.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melitaea_cinxia/GCA_905220565.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/geneset/2021_05/Melitaea_cinxia-GCA_905220565.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1/genome/Melitaea_cinxia-GCA_905220565.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melitaea_cinxia/GCA_905220565.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Melitaea_cinxia/GCA_905220565.1
   rapid_link: https://rapid.ensembl.org/Melitaea_cinxia_gca905220565v1/Info/Index
   alternate: https://rapid.ensembl.org/Melitaea_cinxia_GCA_905220555.1/Info/Index
 
@@ -1775,13 +1775,13 @@
   image: Lepidoptera.png
   accession: GCA_905220545.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/genome/Mellicta_athalia-GCA_905220545.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mellicta_athalia/GCA_905220545.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/geneset/2021_06/Mellicta_athalia-GCA_905220545.1-2021_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1/genome/Mellicta_athalia-GCA_905220545.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mellicta_athalia/GCA_905220545.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mellicta_athalia/GCA_905220545.1
   rapid_link: https://rapid.ensembl.org/Mellicta_athalia_gca905220545v1/Info/Index
   alternate: https://rapid.ensembl.org/Mellicta_athalia_GCA_905220535.1/Info/Index
 
@@ -1789,13 +1789,13 @@
   image: Lepidoptera.png
   accession: GCA_916614155.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/genome/Mesoligia_furuncula-GCA_916614155.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mesoligia_furuncula/GCA_916614155.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/geneset/2021_12/Mesoligia_furuncula-GCA_916614155.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1/genome/Mesoligia_furuncula-GCA_916614155.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mesoligia_furuncula/GCA_916614155.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mesoligia_furuncula/GCA_916614155.1
   rapid_link: https://rapid.ensembl.org/Mesoligia_furuncula_gca916614155v1/Info/Index
   alternate: https://rapid.ensembl.org/Mesoligia_furuncula_GCA_916611985.1/Info/Index
 
@@ -1803,13 +1803,13 @@
   image: Lepidoptera.png
   accession: GCA_905332985.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/genome/Mimas_tiliae-GCA_905332985.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mimas_tiliae/GCA_905332985.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/geneset/2021_12/Mimas_tiliae-GCA_905332985.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1/genome/Mimas_tiliae-GCA_905332985.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mimas_tiliae/GCA_905332985.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mimas_tiliae/GCA_905332985.1
   rapid_link: https://rapid.ensembl.org/Mimas_tiliae_gca905332985v1/Info/Index
   alternate: https://rapid.ensembl.org/Mimas_tiliae_GCA_905333085.1/Info/Index
 
@@ -1817,26 +1817,26 @@
   image: Arthropods.png
   accession: GCA_917499265.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/genome/Mimumesa_dahlbomi-GCA_917499265.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mimumesa_dahlbomi/GCA_917499265.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/geneset/2022_02/Mimumesa_dahlbomi-GCA_917499265.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1/genome/Mimumesa_dahlbomi-GCA_917499265.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mimumesa_dahlbomi/GCA_917499265.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mimumesa_dahlbomi/GCA_917499265.1
   rapid_link: https://rapid.ensembl.org/Mimumesa_dahlbomi_gca917499265v1/Info/Index
 
 - species: Myathropa florea
   image: Arthropods.png
   accession: GCA_930367185.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/genome/Myathropa_florea-GCA_930367185.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/myathropa_florea/GCA_930367185.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/geneset/2022_03/Myathropa_florea-GCA_930367185.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1/genome/Myathropa_florea-GCA_930367185.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/myathropa_florea/GCA_930367185.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Myathropa_florea/GCA_930367185.1
   rapid_link: https://rapid.ensembl.org/Myathropa_florea_gca930367185v1/Info/Index
   alternate: https://rapid.ensembl.org/Myathropa_florea_GCA_930367245.1/Info/Index
 
@@ -1844,72 +1844,72 @@
   image: Lepidoptera.png
   accession: GCA_910589285.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/genome/Mythimna_ferrago-GCA_910589285.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_ferrago/GCA_910589285.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/geneset/2021_11/Mythimna_ferrago-GCA_910589285.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1/genome/Mythimna_ferrago-GCA_910589285.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_ferrago/GCA_910589285.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.1
   rapid_link: https://rapid.ensembl.org/Mythimna_ferrago_gca910589285v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_ferrago_GCA_910589285.1/mythimna_ferrago_gca910589285v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_ferrago_GCA_910589285.1/mythimna_ferrago_gca910589285v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Mythimna_ferrago_GCA_910589535.1/Info/Index
 
 - species: Mythimna ferrago
   image: Lepidoptera.png
   accession: GCA_910589285.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/genome/Mythimna_ferrago-GCA_910589285.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_ferrago/GCA_910589285.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/geneset/2022_03/Mythimna_ferrago-GCA_910589285.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2/genome/Mythimna_ferrago-GCA_910589285.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_ferrago/GCA_910589285.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_ferrago/GCA_910589285.2
   rapid_link: https://rapid.ensembl.org/Mythimna_ferrago_gca910589285v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_ferrago_GCA_910589285.2/mythimna_ferrago_gca910589285v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_ferrago_GCA_910589285.2/mythimna_ferrago_gca910589285v2_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Mythimna_ferrago_GCA_910589535.2/Info/Index
 
 - species: Mythimna impura
   image: Lepidoptera.png
   accession: GCA_905147345.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/genome/Mythimna_impura-GCA_905147345.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_impura/GCA_905147345.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/geneset/2021_11/Mythimna_impura-GCA_905147345.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1/genome/Mythimna_impura-GCA_905147345.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_impura/GCA_905147345.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.1
   rapid_link: https://rapid.ensembl.org/Mythimna_impura_gca905147345v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_impura_GCA_905147345.1/mythimna_impura_gca905147345v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_impura_GCA_905147345.1/mythimna_impura_gca905147345v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Mythimna_impura_GCA_905147275.1/Info/Index
 
 - species: Mythimna impura
   image: Lepidoptera.png
   accession: GCA_905147345.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/genome/Mythimna_impura-GCA_905147345.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_impura/GCA_905147345.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/geneset/2022_03/Mythimna_impura-GCA_905147345.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2/genome/Mythimna_impura-GCA_905147345.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mythimna_impura/GCA_905147345.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mythimna_impura/GCA_905147345.2
   rapid_link: https://rapid.ensembl.org/Mythimna_impura_gca905147345v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_impura_GCA_905147345.2/mythimna_impura_gca905147345v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/mythimna_impura_GCA_905147345.2/mythimna_impura_gca905147345v2_busco_short_summary.txt
 
 - species: Noctua fimbriata
   image: Lepidoptera.png
   accession: GCA_905163415.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/genome/Noctua_fimbriata-GCA_905163415.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_fimbriata/GCA_905163415.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/geneset/2022_03/Noctua_fimbriata-GCA_905163415.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1/genome/Noctua_fimbriata-GCA_905163415.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_fimbriata/GCA_905163415.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_fimbriata/GCA_905163415.1
   rapid_link: https://rapid.ensembl.org/Noctua_fimbriata_gca905163415v1/Info/Index
   alternate: https://rapid.ensembl.org/Noctua_fimbriata_GCA_905163425.1/Info/Index
 
@@ -1917,13 +1917,13 @@
   image: Lepidoptera.png
   accession: GCA_910589295.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/genome/Noctua_janthe-GCA_910589295.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_janthe/GCA_910589295.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/geneset/2021_12/Noctua_janthe-GCA_910589295.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1/genome/Noctua_janthe-GCA_910589295.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_janthe/GCA_910589295.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_janthe/GCA_910589295.1
   rapid_link: https://rapid.ensembl.org/Noctua_janthe_gca910589295v1/Info/Index
   alternate: https://rapid.ensembl.org/Noctua_janthe_GCA_910589505.1/Info/Index
 
@@ -1931,13 +1931,13 @@
   image: Lepidoptera.png
   accession: GCA_905220335.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/genome/Noctua_pronuba-GCA_905220335.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_pronuba/GCA_905220335.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/geneset/2021_12/Noctua_pronuba-GCA_905220335.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1/genome/Noctua_pronuba-GCA_905220335.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/noctua_pronuba/GCA_905220335.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Noctua_pronuba/GCA_905220335.1
   rapid_link: https://rapid.ensembl.org/Noctua_pronuba_gca905220335v1/Info/Index
   alternate: https://rapid.ensembl.org/Noctua_pronuba_GCA_905220345.1/Info/Index
 
@@ -1945,28 +1945,28 @@
   image: Arthropods.png
   accession: GCA_907165295.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/genome/Nomada_fabriciana-GCA_907165295.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nomada_fabriciana/GCA_907165295.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/geneset/2021_11/Nomada_fabriciana-GCA_907165295.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1/genome/Nomada_fabriciana-GCA_907165295.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nomada_fabriciana/GCA_907165295.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Nomada_fabriciana/GCA_907165295.1
   rapid_link: https://rapid.ensembl.org/Nomada_fabriciana_gca907165295v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nomada_fabriciana_GCA_907165295.1/nomada_fabriciana_gca907165295v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nomada_fabriciana_GCA_907165295.1/nomada_fabriciana_gca907165295v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Nomada_fabriciana_GCA_907165305.1/Info/Index
 
 - species: Notocelia uddmanniana
   image: Lepidoptera.png
   accession: GCA_905163555.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/genome/Notocelia_uddmanniana-GCA_905163555.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notocelia_uddmanniana/GCA_905163555.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/geneset/2022_03/Notocelia_uddmanniana-GCA_905163555.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1/genome/Notocelia_uddmanniana-GCA_905163555.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notocelia_uddmanniana/GCA_905163555.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Notocelia_uddmanniana/GCA_905163555.1
   rapid_link: https://rapid.ensembl.org/Notocelia_uddmanniana_gca905163555v1/Info/Index
   alternate: https://rapid.ensembl.org/Notocelia_uddmanniana_GCA_905163575.1/Info/Index
 
@@ -1974,116 +1974,116 @@
   image: Lepidoptera.png
   accession: GCA_905147325.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/genome/Notodonta_dromedarius-GCA_905147325.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notodonta_dromedarius/GCA_905147325.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/geneset/2021_11/Notodonta_dromedarius-GCA_905147325.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1/genome/Notodonta_dromedarius-GCA_905147325.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notodonta_dromedarius/GCA_905147325.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Notodonta_dromedarius/GCA_905147325.1
   rapid_link: https://rapid.ensembl.org/Notodonta_dromedarius_gca905147325v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/notodonta_dromedarius_GCA_905147325.1/notodonta_dromedarius_gca905147325v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/notodonta_dromedarius_GCA_905147325.1/notodonta_dromedarius_gca905147325v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Notodonta_dromedarius_GCA_905147855.1/Info/Index
 
 - species: Nymphalis polychloros
   image: Lepidoptera.png
   accession: GCA_905220585.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/genome/Nymphalis_polychloros-GCA_905220585.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_polychloros/GCA_905220585.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/geneset/2021_11/Nymphalis_polychloros-GCA_905220585.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1/genome/Nymphalis_polychloros-GCA_905220585.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_polychloros/GCA_905220585.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.1
   rapid_link: https://rapid.ensembl.org/Nymphalis_polychloros_gca905220585v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_polychloros_GCA_905220585.1/nymphalis_polychloros_gca905220585v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_polychloros_GCA_905220585.1/nymphalis_polychloros_gca905220585v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Nymphalis_polychloros_GCA_905220575.1/Info/Index
 
 - species: Nymphalis polychloros
   image: Lepidoptera.png
   accession: GCA_905220585.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/genome/Nymphalis_polychloros-GCA_905220585.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_polychloros/GCA_905220585.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/geneset/2022_03/Nymphalis_polychloros-GCA_905220585.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2/genome/Nymphalis_polychloros-GCA_905220585.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_polychloros/GCA_905220585.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_polychloros/GCA_905220585.2
   rapid_link: https://rapid.ensembl.org/Nymphalis_polychloros_gca905220585v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_polychloros_GCA_905220585.2/nymphalis_polychloros_gca905220585v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_polychloros_GCA_905220585.2/nymphalis_polychloros_gca905220585v2_busco_short_summary.txt
 
 - species: Nymphalis urticae
   image: Lepidoptera.png
   accession: GCA_905147175.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/genome/Nymphalis_urticae-GCA_905147175.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_urticae/GCA_905147175.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/geneset/2021_11/Nymphalis_urticae-GCA_905147175.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1/genome/Nymphalis_urticae-GCA_905147175.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_urticae/GCA_905147175.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.1
   rapid_link: https://rapid.ensembl.org/Nymphalis_urticae_gca905147175v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_urticae_GCA_905147175.1/nymphalis_urticae_gca905147175v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_urticae_GCA_905147175.1/nymphalis_urticae_gca905147175v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Nymphalis_urticae_GCA_905147055.1/Info/Index
 
 - species: Nymphalis urticae
   image: Lepidoptera.png
   accession: GCA_905147175.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/genome/Nymphalis_urticae-GCA_905147175.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_urticae/GCA_905147175.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/geneset/2022_03/Nymphalis_urticae-GCA_905147175.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2/genome/Nymphalis_urticae-GCA_905147175.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nymphalis_urticae/GCA_905147175.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Nymphalis_urticae/GCA_905147175.2
   rapid_link: https://rapid.ensembl.org/Nymphalis_urticae_gca905147175v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_urticae_GCA_905147175.2/nymphalis_urticae_gca905147175v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nymphalis_urticae_GCA_905147175.2/nymphalis_urticae_gca905147175v2_busco_short_summary.txt
 
 - species: Nysson spinosus
   image: Arthropods.png
   accession: GCA_910591585.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/genome/Nysson_spinosus-GCA_910591585.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nysson_spinosus/GCA_910591585.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/geneset/2021_11/Nysson_spinosus-GCA_910591585.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1/genome/Nysson_spinosus-GCA_910591585.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/nysson_spinosus/GCA_910591585.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Nysson_spinosus/GCA_910591585.1
   rapid_link: https://rapid.ensembl.org/Nysson_spinosus_gca910591585v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nysson_spinosus_GCA_910591585.1/nysson_spinosus_gca910591585v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/nysson_spinosus_GCA_910591585.1/nysson_spinosus_gca910591585v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Nysson_spinosus_GCA_910591465.1/Info/Index
 
 - species: Ochlodes sylvanus
   image: Lepidoptera.png
   accession: GCA_905404295.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/genome/Ochlodes_sylvanus-GCA_905404295.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ochlodes_sylvanus/GCA_905404295.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/geneset/2021_11/Ochlodes_sylvanus-GCA_905404295.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1/genome/Ochlodes_sylvanus-GCA_905404295.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ochlodes_sylvanus/GCA_905404295.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ochlodes_sylvanus/GCA_905404295.1
   rapid_link: https://rapid.ensembl.org/Ochlodes_sylvanus_gca905404295v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ochlodes_sylvanus_GCA_905404295.1/ochlodes_sylvanus_gca905404295v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ochlodes_sylvanus_GCA_905404295.1/ochlodes_sylvanus_gca905404295v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ochlodes_sylvanus_GCA_905404205.1/Info/Index
 
 - species: Ochropleura plecta
   image: Lepidoptera.png
   accession: GCA_905475445.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/genome/Ochropleura_plecta-GCA_905475445.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ochropleura_plecta/GCA_905475445.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/geneset/2021_12/Ochropleura_plecta-GCA_905475445.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1/genome/Ochropleura_plecta-GCA_905475445.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ochropleura_plecta/GCA_905475445.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ochropleura_plecta/GCA_905475445.1
   rapid_link: https://rapid.ensembl.org/Ochropleura_plecta_gca905475445v1/Info/Index
   alternate: https://rapid.ensembl.org/Ochropleura_plecta_GCA_905475425.1/Info/Index
 
@@ -2091,28 +2091,28 @@
   image: Arthropods.png
   accession: GCA_910593695.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/genome/Ocypus_olens-GCA_910593695.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ocypus_olens/GCA_910593695.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/geneset/2021_12/Ocypus_olens-GCA_910593695.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1/genome/Ocypus_olens-GCA_910593695.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ocypus_olens/GCA_910593695.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ocypus_olens/GCA_910593695.1
   rapid_link: https://rapid.ensembl.org/Ocypus_olens_gca910593695v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ocypus_olens_GCA_910593695.1/ocypus_olens_gca910593695v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/ocypus_olens_GCA_910593695.1/ocypus_olens_gca910593695v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Ocypus_olens_GCA_910593855.1/Info/Index
 
 - species: Omphaloscelis lunosa
   image: Lepidoptera.png
   accession: GCA_916610215.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/genome/Omphaloscelis_lunosa-GCA_916610215.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/omphaloscelis_lunosa/GCA_916610215.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/geneset/2021_12/Omphaloscelis_lunosa-GCA_916610215.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1/genome/Omphaloscelis_lunosa-GCA_916610215.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/omphaloscelis_lunosa/GCA_916610215.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Omphaloscelis_lunosa/GCA_916610215.1
   rapid_link: https://rapid.ensembl.org/Omphaloscelis_lunosa_gca916610215v1/Info/Index
   alternate: https://rapid.ensembl.org/Omphaloscelis_lunosa_GCA_916610225.1/Info/Index
 
@@ -2120,13 +2120,13 @@
   image: Lepidoptera.png
   accession: GCA_916999025.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/genome/Orgyia_antiqua-GCA_916999025.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/orgyia_antiqua/GCA_916999025.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/geneset/2022_02/Orgyia_antiqua-GCA_916999025.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1/genome/Orgyia_antiqua-GCA_916999025.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/orgyia_antiqua/GCA_916999025.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Orgyia_antiqua/GCA_916999025.1
   rapid_link: https://rapid.ensembl.org/Orgyia_antiqua_gca916999025v1/Info/Index
   alternate: https://rapid.ensembl.org/Orgyia_antiqua_GCA_917414775.1/Info/Index
 
@@ -2134,13 +2134,13 @@
   image: Arthropods.png
   accession: GCA_907164935.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/genome/Osmia_bicornis_bicornis-GCA_907164935.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/osmia_bicornis_bicornis/GCA_907164935.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/geneset/2021_11/Osmia_bicornis_bicornis-GCA_907164935.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1/genome/Osmia_bicornis_bicornis-GCA_907164935.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/osmia_bicornis_bicornis/GCA_907164935.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Osmia_bicornis_bicornis/GCA_907164935.1
   rapid_link: https://rapid.ensembl.org/Osmia_bicornis_gca907164935v1/Info/Index
   alternate: https://rapid.ensembl.org/Osmia_bicornis_bicornis_GCA_907164925.1/Info/Index
 
@@ -2148,26 +2148,26 @@
   image: Lepidoptera.png
   accession: GCA_911728535.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/genome/Pammene_fasciana-GCA_911728535.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pammene_fasciana/GCA_911728535.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/geneset/2021_12/Pammene_fasciana-GCA_911728535.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1/genome/Pammene_fasciana-GCA_911728535.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pammene_fasciana/GCA_911728535.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pammene_fasciana/GCA_911728535.1
   rapid_link: https://rapid.ensembl.org/Pammene_fasciana_gca911728535v1/Info/Index
 
 - species: Papilio machaon
   image: Lepidoptera.png
   accession: GCA_912999745.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/genome/Papilio_machaon-GCA_912999745.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/papilio_machaon/GCA_912999745.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/geneset/2021_11/Papilio_machaon-GCA_912999745.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1/genome/Papilio_machaon-GCA_912999745.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/papilio_machaon/GCA_912999745.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Papilio_machaon/GCA_912999745.1
   rapid_link: https://rapid.ensembl.org/Papilio_machaon_gca912999745v1/Info/Index
   alternate: https://rapid.ensembl.org/Papilio_machaon_GCA_912999765.1/Info/Index
 
@@ -2175,13 +2175,13 @@
   image: Lepidoptera.png
   accession: GCA_910589355.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/genome/Parapoynx_stratiotata-GCA_910589355.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parapoynx_stratiotata/GCA_910589355.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/geneset/2021_11/Parapoynx_stratiotata-GCA_910589355.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1/genome/Parapoynx_stratiotata-GCA_910589355.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parapoynx_stratiotata/GCA_910589355.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Parapoynx_stratiotata/GCA_910589355.1
   rapid_link: https://rapid.ensembl.org/Parapoynx_stratiotata_gca910589355v1/Info/Index
   alternate: https://rapid.ensembl.org/Parapoynx_stratiotata_GCA_910589245.1/Info/Index
 
@@ -2189,41 +2189,41 @@
   image: Lepidoptera.png
   accession: GCA_905163445.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/genome/Pararge_aegeria-GCA_905163445.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pararge_aegeria/GCA_905163445.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/geneset/2021_05/Pararge_aegeria-GCA_905163445.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1/genome/Pararge_aegeria-GCA_905163445.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pararge_aegeria/GCA_905163445.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pararge_aegeria/GCA_905163445.1
   rapid_link: https://rapid.ensembl.org/Pararge_aegeria_gca905163445v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pararge_aegeria_GCA_905163445.1/pararge_aegeria_gca905163445v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pararge_aegeria_GCA_905163445.1/pararge_aegeria_gca905163445v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Pararge_aegeria_GCA_905163545.1/Info/Index
 
 - species: Patella pellucida
   image: Metazoa.png
   accession: GCA_917208275.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/genome/Patella_pellucida-GCA_917208275.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/patella_pellucida/GCA_917208275.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/geneset/2022_02/Patella_pellucida-GCA_917208275.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1/genome/Patella_pellucida-GCA_917208275.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/patella_pellucida/GCA_917208275.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Patella_pellucida/GCA_917208275.1
   rapid_link: https://rapid.ensembl.org/Patella_pellucida_gca917208275v1/Info/Index
 
 - species: Peribatodes rhomboidaria
   image: Lepidoptera.png
   accession: GCA_911728515.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/genome/Peribatodes_rhomboidaria-GCA_911728515.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/peribatodes_rhomboidaria/GCA_911728515.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/geneset/2021_12/Peribatodes_rhomboidaria-GCA_911728515.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1/genome/Peribatodes_rhomboidaria-GCA_911728515.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/peribatodes_rhomboidaria/GCA_911728515.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Peribatodes_rhomboidaria/GCA_911728515.1
   rapid_link: https://rapid.ensembl.org/Peribatodes_rhomboidaria_gca911728515v1/Info/Index
   alternate: https://rapid.ensembl.org/Peribatodes_rhomboidaria_GCA_911728505.1/Info/Index
 
@@ -2231,28 +2231,28 @@
   image: Lepidoptera.png
   accession: GCA_905147815.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/genome/Phalera_bucephala-GCA_905147815.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phalera_bucephala/GCA_905147815.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/geneset/2022_01/Phalera_bucephala-GCA_905147815.2-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2/genome/Phalera_bucephala-GCA_905147815.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phalera_bucephala/GCA_905147815.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Phalera_bucephala/GCA_905147815.2
   rapid_link: https://rapid.ensembl.org/Phalera_bucephala_gca905147815v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/phalera_bucephala_GCA_905147815.2/phalera_bucephala_gca905147815v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/phalera_bucephala_GCA_905147815.2/phalera_bucephala_gca905147815v2_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Phalera_bucephala_GCA_905147805.2/Info/Index
 
 - species: Pheosia gnoma
   image: Lepidoptera.png
   accession: GCA_905404115.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/genome/Pheosia_gnoma-GCA_905404115.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pheosia_gnoma/GCA_905404115.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/geneset/2021_11/Pheosia_gnoma-GCA_905404115.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1/genome/Pheosia_gnoma-GCA_905404115.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pheosia_gnoma/GCA_905404115.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_gnoma/GCA_905404115.1
   rapid_link: https://rapid.ensembl.org/Pheosia_gnoma_gca905404115v1/Info/Index
   alternate: https://rapid.ensembl.org/Pheosia_gnoma_GCA_905404125.1/Info/Index
 
@@ -2260,43 +2260,43 @@
   image: Lepidoptera.png
   accession: GCA_905333125.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/genome/Pheosia_tremula-GCA_905333125.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pheosia_tremula/GCA_905333125.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/geneset/2021_11/Pheosia_tremula-GCA_905333125.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1/genome/Pheosia_tremula-GCA_905333125.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pheosia_tremula/GCA_905333125.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pheosia_tremula/GCA_905333125.1
   rapid_link: https://rapid.ensembl.org/Pheosia_tremula_gca905333125v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pheosia_tremula_GCA_905333125.1/pheosia_tremula_gca905333125v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pheosia_tremula_GCA_905333125.1/pheosia_tremula_gca905333125v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Pheosia_tremula_GCA_905333115.1/Info/Index
 
 - species: Phlogophora meticulosa
   image: Lepidoptera.png
   accession: GCA_905147745.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/genome/Phlogophora_meticulosa-GCA_905147745.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phlogophora_meticulosa/GCA_905147745.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/geneset/2021_11/Phlogophora_meticulosa-GCA_905147745.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1/genome/Phlogophora_meticulosa-GCA_905147745.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phlogophora_meticulosa/GCA_905147745.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Phlogophora_meticulosa/GCA_905147745.1
   rapid_link: https://rapid.ensembl.org/Phlogophora_meticulosa_gca905147745v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/phlogophora_meticulosa_GCA_905147745.1/phlogophora_meticulosa_gca905147745v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/phlogophora_meticulosa_GCA_905147745.1/phlogophora_meticulosa_gca905147745v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Phlogophora_meticulosa_GCA_905147725.1/Info/Index
 
 - species: Pieris brassicae
   image: Lepidoptera.png
   accession: GCA_905147105.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/genome/Pieris_brassicae-GCA_905147105.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_brassicae/GCA_905147105.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/geneset/2021_05/Pieris_brassicae-GCA_905147105.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1/genome/Pieris_brassicae-GCA_905147105.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_brassicae/GCA_905147105.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_brassicae/GCA_905147105.1
   rapid_link: https://rapid.ensembl.org/Pieris_brassicae_gca905147105v1/Info/Index
   alternate: https://rapid.ensembl.org/Pieris_brassicae_GCA_905147085.1/Info/Index
 
@@ -2304,13 +2304,13 @@
   image: Lepidoptera.png
   accession: GCA_905231885.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/genome/Pieris_napi-GCA_905231885.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905231885.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/geneset/2022_03/Pieris_napi-GCA_905231885.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1/genome/Pieris_napi-GCA_905231885.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905231885.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905231885.1
   rapid_link: https://rapid.ensembl.org/Pieris_napi_gca905231885v1/Info/Index
   alternate: https://rapid.ensembl.org/Pieris_napi_GCA_905231895.1/Info/Index
 
@@ -2318,13 +2318,13 @@
   image: Lepidoptera.png
   accession: GCA_905475465.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/genome/Pieris_napi-GCA_905475465.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905475465.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/geneset/2021_11/Pieris_napi-GCA_905475465.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1/genome/Pieris_napi-GCA_905475465.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905475465.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.1
   rapid_link: https://rapid.ensembl.org/Pieris_napi_gca905475465v1/Info/Index
   alternate: https://rapid.ensembl.org/Pieris_napi_GCA_905475415.1/Info/Index
 
@@ -2332,27 +2332,27 @@
   image: Lepidoptera.png
   accession: GCA_905475465.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/genome/Pieris_napi-GCA_905475465.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905475465.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/geneset/2022_03/Pieris_napi-GCA_905475465.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2/genome/Pieris_napi-GCA_905475465.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_napi/GCA_905475465.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_napi/GCA_905475465.2
   rapid_link: https://rapid.ensembl.org/Pieris_napi_gca905475465v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pieris_napi_GCA_905475465.2/pieris_napi_gca905475465v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/pieris_napi_GCA_905475465.2/pieris_napi_gca905475465v2_busco_short_summary.txt
 
 - species: Pieris rapae
   image: Lepidoptera.png
   accession: GCA_905147795.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/genome/Pieris_rapae-GCA_905147795.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_rapae/GCA_905147795.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/geneset/2021_05/Pieris_rapae-GCA_905147795.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1/genome/Pieris_rapae-GCA_905147795.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pieris_rapae/GCA_905147795.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pieris_rapae/GCA_905147795.1
   rapid_link: https://rapid.ensembl.org/Pieris_rapae_gca905147795v1/Info/Index
   alternate: https://rapid.ensembl.org/Pieris_rapae_GCA_905147735.1/Info/Index
 
@@ -2360,13 +2360,13 @@
   image: Arthropods.png
   accession: GCA_916050605.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/genome/Platycheirus_albimanus-GCA_916050605.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/platycheirus_albimanus/GCA_916050605.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/geneset/2021_12/Platycheirus_albimanus-GCA_916050605.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1/genome/Platycheirus_albimanus-GCA_916050605.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/platycheirus_albimanus/GCA_916050605.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.1
   rapid_link: https://rapid.ensembl.org/Platycheirus_albimanus_gca916050605v1/Info/Index
   alternate: https://rapid.ensembl.org/Platycheirus_albimanus_GCA_916050315.1/Info/Index
 
@@ -2374,26 +2374,26 @@
   image: Arthropods.png
   accession: GCA_916050605.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/genome/Platycheirus_albimanus-GCA_916050605.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/platycheirus_albimanus/GCA_916050605.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/geneset/2022_03/Platycheirus_albimanus-GCA_916050605.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2/genome/Platycheirus_albimanus-GCA_916050605.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/platycheirus_albimanus/GCA_916050605.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Platycheirus_albimanus/GCA_916050605.2
   rapid_link: https://rapid.ensembl.org/Platycheirus_albimanus_gca916050605v2/Info/Index
 
 - species: Plebejus argus
   image: Lepidoptera.png
   accession: GCA_905404155.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/genome/Plebejus_argus-GCA_905404155.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/plebejus_argus/GCA_905404155.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/geneset/2021_11/Plebejus_argus-GCA_905404155.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1/genome/Plebejus_argus-GCA_905404155.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/plebejus_argus/GCA_905404155.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.1
   rapid_link: https://rapid.ensembl.org/Plebejus_argus_gca905404155v1/Info/Index
   alternate: https://rapid.ensembl.org/Plebejus_argus_GCA_905404165.1/Info/Index
 
@@ -2401,27 +2401,27 @@
   image: Lepidoptera.png
   accession: GCA_905404155.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/genome/Plebejus_argus-GCA_905404155.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/plebejus_argus/GCA_905404155.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/geneset/2022_03/Plebejus_argus-GCA_905404155.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2/genome/Plebejus_argus-GCA_905404155.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/plebejus_argus/GCA_905404155.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Plebejus_argus/GCA_905404155.2
   rapid_link: https://rapid.ensembl.org/Plebejus_argus_gca905404155v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/plebejus_argus_GCA_905404155.2/plebejus_argus_gca905404155v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/plebejus_argus_GCA_905404155.2/plebejus_argus_gca905404155v2_busco_short_summary.txt
 
 - species: Pollenia angustigena
   image: Arthropods.png
   accession: GCA_930367215.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/genome/Pollenia_angustigena-GCA_930367215.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pollenia_angustigena/GCA_930367215.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/geneset/2022_03/Pollenia_angustigena-GCA_930367215.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1/genome/Pollenia_angustigena-GCA_930367215.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pollenia_angustigena/GCA_930367215.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pollenia_angustigena/GCA_930367215.1
   rapid_link: https://rapid.ensembl.org/Pollenia_angustigena_gca930367215v1/Info/Index
   alternate: https://rapid.ensembl.org/Pollenia_angustigena_GCA_930374645.1/Info/Index
 
@@ -2429,13 +2429,13 @@
   image: Arthropods.png
   accession: GCA_911728475.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/genome/Pterostichus_madidus-GCA_911728475.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pterostichus_madidus/GCA_911728475.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/geneset/2021_12/Pterostichus_madidus-GCA_911728475.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1/genome/Pterostichus_madidus-GCA_911728475.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pterostichus_madidus/GCA_911728475.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.1
   rapid_link: https://rapid.ensembl.org/Pterostichus_madidus_gca911728475v1/Info/Index
   alternate: https://rapid.ensembl.org/Pterostichus_madidus_GCA_911728425.1/Info/Index
 
@@ -2443,26 +2443,26 @@
   image: Arthropods.png
   accession: GCA_911728475.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/genome/Pterostichus_madidus-GCA_911728475.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pterostichus_madidus/GCA_911728475.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/geneset/2022_03/Pterostichus_madidus-GCA_911728475.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2/genome/Pterostichus_madidus-GCA_911728475.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pterostichus_madidus/GCA_911728475.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pterostichus_madidus/GCA_911728475.2
   rapid_link: https://rapid.ensembl.org/Pterostichus_madidus_gca911728475v2/Info/Index
 
 - species: Ptilodon capucinus
   image: Lepidoptera.png
   accession: GCA_914767695.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/genome/Ptilodon_capucinus-GCA_914767695.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ptilodon_capucinus/GCA_914767695.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/geneset/2021_12/Ptilodon_capucinus-GCA_914767695.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1/genome/Ptilodon_capucinus-GCA_914767695.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ptilodon_capucinus/GCA_914767695.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ptilodon_capucinus/GCA_914767695.1
   rapid_link: https://rapid.ensembl.org/Ptilodon_capucinus_gca914767695v1/Info/Index
   alternate: https://rapid.ensembl.org/Ptilodon_capucinus_GCA_914767775.1/Info/Index
 
@@ -2470,13 +2470,13 @@
   image: Lepidoptera.png
   accession: GCA_911387765.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/genome/Pyrgus_malvae-GCA_911387765.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pyrgus_malvae/GCA_911387765.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/geneset/2021_11/Pyrgus_malvae-GCA_911387765.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1/genome/Pyrgus_malvae-GCA_911387765.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pyrgus_malvae/GCA_911387765.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pyrgus_malvae/GCA_911387765.1
   rapid_link: https://rapid.ensembl.org/Pyrgus_malvae_gca911387765v1/Info/Index
   alternate: https://rapid.ensembl.org/Pyrgus_malvae_GCA_911387725.1/Info/Index
 
@@ -2484,39 +2484,39 @@
   image: Arthropods.png
   accession: GCA_905333025.2
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/genome/Pyrochroa_serraticornis-GCA_905333025.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pyrochroa_serraticornis/GCA_905333025.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/geneset/2022_03/Pyrochroa_serraticornis-GCA_905333025.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2/genome/Pyrochroa_serraticornis-GCA_905333025.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pyrochroa_serraticornis/GCA_905333025.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pyrochroa_serraticornis/GCA_905333025.2
   rapid_link: https://rapid.ensembl.org/Pyrochroa_serraticornis_gca905333025v2/Info/Index
 
 - species: Rattus norvegicus (BN/NHsdMcwi)
   image: Mammals.png
   accession: GCA_015227675.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/genome/Rattus_norvegicus-GCA_015227675.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rattus_norvegicus/GCA_015227675.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/genome/Rattus_norvegicus-GCA_015227675.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rattus_norvegicus/GCA_015227675.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2
   ensembl_link: https://www.ensembl.org/Rattus_norvegicus/Info/Index
 
 - species: Rhagonycha fulva
   image: Arthropods.png
   accession: GCA_905340355.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/genome/Rhagonycha_fulva-GCA_905340355.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rhagonycha_fulva/GCA_905340355.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/geneset/2021_12/Rhagonycha_fulva-GCA_905340355.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1/genome/Rhagonycha_fulva-GCA_905340355.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rhagonycha_fulva/GCA_905340355.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Rhagonycha_fulva/GCA_905340355.1
   rapid_link: https://rapid.ensembl.org/Rhagonycha_fulva_gca905340355v1/Info/Index
   alternate: https://rapid.ensembl.org/Rhagonycha_fulva_GCA_905340395.1/Info/Index
 
@@ -2524,26 +2524,26 @@
   image: Fish.png
   accession: GCA_901001165.1
   annotation_method: Ensembl genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/release-106/gtf/salmo_trutta/Salmo_trutta.fSalTru1.1.106.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-106/gff3/salmo_trutta/Salmo_trutta.fSalTru1.1.106.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-106/fasta/salmo_trutta/pep/Salmo_trutta.fSalTru1.1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-106/fasta/salmo_trutta/cdna/Salmo_trutta.fSalTru1.1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-106/fasta/salmo_trutta/dna/Salmo_trutta.fSalTru1.1.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_trutta/GCA_901001165.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-106
+  annotation_gtf: https://ftp.ensembl.org/pub/release-106/gtf/salmo_trutta/Salmo_trutta.fSalTru1.1.106.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-106/gff3/salmo_trutta/Salmo_trutta.fSalTru1.1.106.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-106/fasta/salmo_trutta/pep/Salmo_trutta.fSalTru1.1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-106/fasta/salmo_trutta/cdna/Salmo_trutta.fSalTru1.1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-106/fasta/salmo_trutta/dna/Salmo_trutta.fSalTru1.1.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_trutta/GCA_901001165.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-106
   ensembl_link: https://www.ensembl.org/Salmo_trutta/Info/Index
 
 - species: Sarcophaga caerulescens
   image: Arthropods.png
   accession: GCA_927399465.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/genome/Sarcophaga_caerulescens-GCA_927399465.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophaga_caerulescens/GCA_927399465.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/geneset/2022_03/Sarcophaga_caerulescens-GCA_927399465.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1/genome/Sarcophaga_caerulescens-GCA_927399465.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophaga_caerulescens/GCA_927399465.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_caerulescens/GCA_927399465.1
   rapid_link: https://rapid.ensembl.org/Sarcophaga_caerulescens_gca927399465v1/Info/Index
   alternate: https://rapid.ensembl.org/Sarcophaga_caerulescens_GCA_927399425.1/Info/Index
 
@@ -2551,13 +2551,13 @@
   image: Arthropods.png
   accession: GCA_930367235.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/genome/Sarcophaga_rosellei-GCA_930367235.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophaga_rosellei/GCA_930367235.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/geneset/2022_03/Sarcophaga_rosellei-GCA_930367235.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1/genome/Sarcophaga_rosellei-GCA_930367235.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophaga_rosellei/GCA_930367235.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophaga_rosellei/GCA_930367235.1
   rapid_link: https://rapid.ensembl.org/Sarcophaga_rosellei_gca930367235v1/Info/Index
   alternate: https://rapid.ensembl.org/Sarcophaga_rosellei_GCA_930367195.1/Info/Index
 
@@ -2565,13 +2565,13 @@
   image: Arthropods.png
   accession: GCA_905146935.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/genome/Scaeva_pyrastri-GCA_905146935.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scaeva_pyrastri/GCA_905146935.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/geneset/2021_12/Scaeva_pyrastri-GCA_905146935.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1/genome/Scaeva_pyrastri-GCA_905146935.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scaeva_pyrastri/GCA_905146935.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Scaeva_pyrastri/GCA_905146935.1
   rapid_link: https://rapid.ensembl.org/Scaeva_pyrastri_gca905146935v1/Info/Index
   alternate: https://rapid.ensembl.org/Scaeva_pyrastri_GCA_905147095.1/Info/Index
 
@@ -2579,13 +2579,13 @@
   image: Lepidoptera.png
   accession: GCA_905475405.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/genome/Schrankia_costaestrigalis-GCA_905475405.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/schrankia_costaestrigalis/GCA_905475405.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/geneset/2021_12/Schrankia_costaestrigalis-GCA_905475405.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1/genome/Schrankia_costaestrigalis-GCA_905475405.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/schrankia_costaestrigalis/GCA_905475405.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Schrankia_costaestrigalis/GCA_905475405.1
   rapid_link: https://rapid.ensembl.org/Schrankia_costaestrigalis_gca905475405v1/Info/Index
   alternate: https://rapid.ensembl.org/Schrankia_costaestrigalis_GCA_905475335.1/Info/Index
 
@@ -2593,64 +2593,64 @@
   image: Mammals.png
   accession: GCA_902686445.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/genome/Sciurus_carolinensis-GCA_902686445.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_carolinensis/GCA_902686445.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/geneset/2020_12/Sciurus_carolinensis-GCA_902686445.2-2020_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2/genome/Sciurus_carolinensis-GCA_902686445.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_carolinensis/GCA_902686445.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_carolinensis/GCA_902686445.2
   rapid_link: https://rapid.ensembl.org/Sciurus_carolinensis_gca902686445v2/Info/Index
 
 - species: Sciurus vulgaris
   image: Mammals.png
   accession: GCA_902686455.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/genome/Sciurus_vulgaris-GCA_902686455.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_vulgaris/GCA_902686455.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/genome/Sciurus_vulgaris-GCA_902686455.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_vulgaris/GCA_902686455.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1
   ensembl_link: https://www.ensembl.org/Sciurus_vulgaris/Info/Index
 
 - species: Sciurus vulgaris
   image: Mammals.png
   accession: GCA_902686455.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/genome/Sciurus_vulgaris-GCA_902686455.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_vulgaris/GCA_902686455.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/geneset/2020_12/Sciurus_vulgaris-GCA_902686455.2-2020_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2/genome/Sciurus_vulgaris-GCA_902686455.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_vulgaris/GCA_902686455.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.2
   rapid_link: https://rapid.ensembl.org/Sciurus_vulgaris_gca902686455v2/Info/Index
 
 - species: Seladonia tumulorum
   image: Arthropods.png
   accession: GCA_913789895.3
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/genome/Seladonia_tumulorum-GCA_913789895.3-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/geneset/2022_03/Seladonia_tumulorum-GCA_913789895.3-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3/genome/Seladonia_tumulorum-GCA_913789895.3-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Seladonia_tumulorum/GCA_913789895.3
   rapid_link: https://rapid.ensembl.org/Seladonia_tumulorum_gca913789895v3/Info/Index
 
 - species: Sesia apiformis
   image: Lepidoptera.png
   accession: GCA_914767545.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/genome/Sesia_apiformis-GCA_914767545.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sesia_apiformis/GCA_914767545.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/geneset/2021_12/Sesia_apiformis-GCA_914767545.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1/genome/Sesia_apiformis-GCA_914767545.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sesia_apiformis/GCA_914767545.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sesia_apiformis/GCA_914767545.1
   rapid_link: https://rapid.ensembl.org/Sesia_apiformis_gca914767545v1/Info/Index
   alternate: https://rapid.ensembl.org/Sesia_apiformis_GCA_914767725.1/Info/Index
 
@@ -2658,26 +2658,26 @@
   image: Arthropods.png
   accession: GCA_913789915.3
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/genome/Sphecodes_monilicornis-GCA_913789915.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sphecodes_monilicornis/GCA_913789915.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/geneset/2022_03/Sphecodes_monilicornis-GCA_913789915.3-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3/genome/Sphecodes_monilicornis-GCA_913789915.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sphecodes_monilicornis/GCA_913789915.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sphecodes_monilicornis/GCA_913789915.3
   rapid_link: https://rapid.ensembl.org/Sphecodes_monilicornis_gca913789915v3/Info/Index
 
 - species: Spilarctia lutea
   image: Lepidoptera.png
   accession: GCA_916048165.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/genome/Spilarctia_lutea-GCA_916048165.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/spilarctia_lutea/GCA_916048165.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/geneset/2021_12/Spilarctia_lutea-GCA_916048165.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1/genome/Spilarctia_lutea-GCA_916048165.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/spilarctia_lutea/GCA_916048165.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Spilarctia_lutea/GCA_916048165.1
   rapid_link: https://rapid.ensembl.org/Spilarctia_lutea_gca916048165v1/Info/Index
   alternate: https://rapid.ensembl.org/Spilarctia_lutea_GCA_916047975.1/Info/Index
 
@@ -2685,13 +2685,13 @@
   image: Lepidoptera.png
   accession: GCA_905220595.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/genome/Spilosoma_lubricipeda-GCA_905220595.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/spilosoma_lubricipeda/GCA_905220595.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/geneset/2021_12/Spilosoma_lubricipeda-GCA_905220595.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1/genome/Spilosoma_lubricipeda-GCA_905220595.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/spilosoma_lubricipeda/GCA_905220595.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Spilosoma_lubricipeda/GCA_905220595.1
   rapid_link: https://rapid.ensembl.org/Spilosoma_lubricipeda_gca905220595v1/Info/Index
   alternate: https://rapid.ensembl.org/Spilosoma_lubricipeda_GCA_905220605.1/Info/Index
 
@@ -2699,13 +2699,13 @@
   image: Arthropods.png
   accession: GCA_905187475.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/genome/Syritta_pipiens-GCA_905187475.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/syritta_pipiens/GCA_905187475.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/geneset/2021_12/Syritta_pipiens-GCA_905187475.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1/genome/Syritta_pipiens-GCA_905187475.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/syritta_pipiens/GCA_905187475.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Syritta_pipiens/GCA_905187475.1
   rapid_link: https://rapid.ensembl.org/Syritta_pipiens_gca905187475v1/Info/Index
   alternate: https://rapid.ensembl.org/Syritta_pipiens_GCA_905147025.1/Info/Index
 
@@ -2713,13 +2713,13 @@
   image: Arthropods.png
   accession: GCA_905220375.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/genome/Tachina_fera-GCA_905220375.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tachina_fera/GCA_905220375.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/geneset/2021_12/Tachina_fera-GCA_905220375.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1/genome/Tachina_fera-GCA_905220375.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tachina_fera/GCA_905220375.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Tachina_fera/GCA_905220375.1
   rapid_link: https://rapid.ensembl.org/Tachina_fera_gca905220375v1/Info/Index
   alternate: https://rapid.ensembl.org/Tachina_fera_GCA_905220395.1/Info/Index
 
@@ -2727,41 +2727,41 @@
   image: Arthropods.png
   accession: GCA_914767705.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/genome/Tenthredo_notha-GCA_914767705.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tenthredo_notha/GCA_914767705.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/geneset/2021_11/Tenthredo_notha-GCA_914767705.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1/genome/Tenthredo_notha-GCA_914767705.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tenthredo_notha/GCA_914767705.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.1
   rapid_link: https://rapid.ensembl.org/Tenthredo_notha_gca914767705v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tenthredo_notha_GCA_914767705.1/tenthredo_notha_gca914767705v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tenthredo_notha_GCA_914767705.1/tenthredo_notha_gca914767705v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Tenthredo_notha_GCA_914767975.1/Info/Index
 
 - species: Tenthredo notha
   image: Arthropods.png
   accession: GCA_914767705.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/genome/Tenthredo_notha-GCA_914767705.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tenthredo_notha/GCA_914767705.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/geneset/2022_03/Tenthredo_notha-GCA_914767705.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2/genome/Tenthredo_notha-GCA_914767705.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tenthredo_notha/GCA_914767705.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Tenthredo_notha/GCA_914767705.2
   rapid_link: https://rapid.ensembl.org/Tenthredo_notha_gca914767705v2/Info/Index
 
 - species: Thecocarcelia acutangulata
   image: Arthropods.png
   accession: GCA_914767995.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/genome/Thecocarcelia_acutangulata-GCA_914767995.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thecocarcelia_acutangulata/GCA_914767995.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/geneset/2022_02/Thecocarcelia_acutangulata-GCA_914767995.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1/genome/Thecocarcelia_acutangulata-GCA_914767995.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thecocarcelia_acutangulata/GCA_914767995.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Thecocarcelia_acutangulata/GCA_914767995.1
   rapid_link: https://rapid.ensembl.org/Thecocarcelia_acutangulata_gca914767995v1/Info/Index
   alternate: https://rapid.ensembl.org/Thecocarcelia_acutangulata_GCA_914767745.1/Info/Index
 
@@ -2769,13 +2769,13 @@
   image: Lepidoptera.png
   accession: GCA_905147785.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/genome/Thyatira_batis-GCA_905147785.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thyatira_batis/GCA_905147785.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/geneset/2021_05/Thyatira_batis-GCA_905147785.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1/genome/Thyatira_batis-GCA_905147785.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thyatira_batis/GCA_905147785.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Thyatira_batis/GCA_905147785.1
   rapid_link: https://rapid.ensembl.org/Thyatira_batis_gca905147785v1/Info/Index
   alternate: https://rapid.ensembl.org/Thyatira_batis_GCA_905147775.1/Info/Index
 
@@ -2783,13 +2783,13 @@
   image: Lepidoptera.png
   accession: GCA_911387775.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/genome/Thymelicus_sylvestris-GCA_911387775.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thymelicus_sylvestris/GCA_911387775.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/geneset/2021_11/Thymelicus_sylvestris-GCA_911387775.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1/genome/Thymelicus_sylvestris-GCA_911387775.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thymelicus_sylvestris/GCA_911387775.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Thymelicus_sylvestris/GCA_911387775.1
   rapid_link: https://rapid.ensembl.org/Thymelicus_sylvestris_gca911387775v1/Info/Index
   alternate: https://rapid.ensembl.org/Thymelicus_sylvestris_GCA_911387695.1/Info/Index
 
@@ -2797,56 +2797,56 @@
   image: Lepidoptera.png
   accession: GCA_910589645.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/genome/Tinea_semifulvella-GCA_910589645.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tinea_semifulvella/GCA_910589645.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/geneset/2021_11/Tinea_semifulvella-GCA_910589645.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1/genome/Tinea_semifulvella-GCA_910589645.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tinea_semifulvella/GCA_910589645.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_semifulvella/GCA_910589645.1
   rapid_link: https://rapid.ensembl.org/Tinea_semifulvella_gca910589645v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tinea_semifulvella_GCA_910589645.1/tinea_semifulvella_gca910589645v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tinea_semifulvella_GCA_910589645.1/tinea_semifulvella_gca910589645v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Tinea_semifulvella_GCA_910589255.1/Info/Index
 
 - species: Tinea trinotella
   image: Lepidoptera.png
   accession: GCA_905220615.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/genome/Tinea_trinotella-GCA_905220615.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tinea_trinotella/GCA_905220615.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/geneset/2021_11/Tinea_trinotella-GCA_905220615.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1/genome/Tinea_trinotella-GCA_905220615.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tinea_trinotella/GCA_905220615.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Tinea_trinotella/GCA_905220615.1
   rapid_link: https://rapid.ensembl.org/Tinea_trinotella_gca905220615v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tinea_trinotella_GCA_905220615.1/tinea_trinotella_gca905220615v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/tinea_trinotella_GCA_905220615.1/tinea_trinotella_gca905220615v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Tinea_trinotella_GCA_905220625.1/Info/Index
 
 - species: Trachurus trachurus
   image: Fish.png
   accession: GCA_905171665.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/genome/Trachurus_trachurus-GCA_905171665.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/trachurus_trachurus/GCA_905171665.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/geneset/2021_03/Trachurus_trachurus-GCA_905171665.1-2021_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1/genome/Trachurus_trachurus-GCA_905171665.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/trachurus_trachurus/GCA_905171665.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Trachurus_trachurus/GCA_905171665.1
   rapid_link: https://rapid.ensembl.org/Trachurus_trachurus_gca905171665v1/Info/Index
 
 - species: Vanessa atalanta
   image: Lepidoptera.png
   accession: GCA_905147765.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/genome/Vanessa_atalanta-GCA_905147765.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_atalanta/GCA_905147765.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/geneset/2021_05/Vanessa_atalanta-GCA_905147765.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1/genome/Vanessa_atalanta-GCA_905147765.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_atalanta/GCA_905147765.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.1
   rapid_link: https://rapid.ensembl.org/Vanessa_atalanta_gca905147765v1/Info/Index
   alternate: https://rapid.ensembl.org/Vanessa_atalanta_GCA_905147705.1/Info/Index
 
@@ -2854,13 +2854,13 @@
   image: Lepidoptera.png
   accession: GCA_905147765.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/genome/Vanessa_atalanta-GCA_905147765.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_atalanta/GCA_905147765.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/geneset/2021_11/Vanessa_atalanta-GCA_905147765.2-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2/genome/Vanessa_atalanta-GCA_905147765.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_atalanta/GCA_905147765.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_atalanta/GCA_905147765.2
   rapid_link: https://rapid.ensembl.org/Vanessa_atalanta_gca905147765v2/Info/Index
   alternate: https://rapid.ensembl.org/Vanessa_atalanta_GCA_905147705.2/Info/Index
 
@@ -2868,13 +2868,13 @@
   image: Lepidoptera.png
   accession: GCA_905220365.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/genome/Vanessa_cardui-GCA_905220365.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_cardui/GCA_905220365.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/geneset/2021_05/Vanessa_cardui-GCA_905220365.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1/genome/Vanessa_cardui-GCA_905220365.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vanessa_cardui/GCA_905220365.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vanessa_cardui/GCA_905220365.1
   rapid_link: https://rapid.ensembl.org/Vanessa_cardui_gca905220365v1/Info/Index
   alternate: https://rapid.ensembl.org/Vanessa_cardui_GCA_905220355.1/Info/Index
 
@@ -2882,70 +2882,70 @@
   image: Arthropods.png
   accession: GCA_910589235.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/genome/Vespa_crabro-GCA_910589235.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespa_crabro/GCA_910589235.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/geneset/2022_03/Vespa_crabro-GCA_910589235.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2/genome/Vespa_crabro-GCA_910589235.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespa_crabro/GCA_910589235.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_crabro/GCA_910589235.2
   rapid_link: https://rapid.ensembl.org/Vespa_crabro_gca910589235v2/Info/Index
 
 - species: Vespa velutina
   image: Arthropods.png
   accession: GCA_912470025.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/genome/Vespa_velutina-GCA_912470025.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespa_velutina/GCA_912470025.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/geneset/2021_11/Vespa_velutina-GCA_912470025.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1/genome/Vespa_velutina-GCA_912470025.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespa_velutina/GCA_912470025.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vespa_velutina/GCA_912470025.1
   rapid_link: https://rapid.ensembl.org/Vespa_velutina_gca912470025v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespa_velutina_GCA_912470025.1/vespa_velutina_gca912470025v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespa_velutina_GCA_912470025.1/vespa_velutina_gca912470025v1_busco_short_summary.txt
 
 - species: Vespula germanica
   image: Arthropods.png
   accession: GCA_905340365.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/genome/Vespula_germanica-GCA_905340365.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespula_germanica/GCA_905340365.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/geneset/2021_11/Vespula_germanica-GCA_905340365.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1/genome/Vespula_germanica-GCA_905340365.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespula_germanica/GCA_905340365.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_germanica/GCA_905340365.1
   rapid_link: https://rapid.ensembl.org/Vespula_germanica_gca905340365v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespula_germanica_GCA_905340365.1/vespula_germanica_gca905340365v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespula_germanica_GCA_905340365.1/vespula_germanica_gca905340365v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Vespula_germanica_GCA_905340295.1/Info/Index
 
 - species: Vespula vulgaris
   image: Arthropods.png
   accession: GCA_905475345.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/genome/Vespula_vulgaris-GCA_905475345.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespula_vulgaris/GCA_905475345.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/geneset/2021_11/Vespula_vulgaris-GCA_905475345.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1/genome/Vespula_vulgaris-GCA_905475345.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/vespula_vulgaris/GCA_905475345.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Vespula_vulgaris/GCA_905475345.1
   rapid_link: https://rapid.ensembl.org/Vespula_vulgaris_gca905475345v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespula_vulgaris_GCA_905475345.1/vespula_vulgaris_gca905475345v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/vespula_vulgaris_GCA_905475345.1/vespula_vulgaris_gca905475345v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Vespula_vulgaris_GCA_905404185.1/Info/Index
 
 - species: Volucella inanis
   image: Arthropods.png
   accession: GCA_907269105.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/genome/Volucella_inanis-GCA_907269105.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/volucella_inanis/GCA_907269105.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/geneset/2021_12/Volucella_inanis-GCA_907269105.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1/genome/Volucella_inanis-GCA_907269105.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/volucella_inanis/GCA_907269105.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inanis/GCA_907269105.1
   rapid_link: https://rapid.ensembl.org/Volucella_inanis_gca907269105v1/Info/Index
   alternate: https://rapid.ensembl.org/Volucella_inanis_GCA_907269115.1/Info/Index
 
@@ -2953,13 +2953,13 @@
   image: Arthropods.png
   accession: GCA_928272305.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/genome/Volucella_inflata-GCA_928272305.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/volucella_inflata/GCA_928272305.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/geneset/2022_03/Volucella_inflata-GCA_928272305.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1/genome/Volucella_inflata-GCA_928272305.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/volucella_inflata/GCA_928272305.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Volucella_inflata/GCA_928272305.1
   rapid_link: https://rapid.ensembl.org/Volucella_inflata_gca928272305v1/Info/Index
   alternate: https://rapid.ensembl.org/Volucella_inflata_GCA_928272175.1/Info/Index
 
@@ -2967,13 +2967,13 @@
   image: Arthropods.png
   accession: GCA_910595825.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/genome/Xanthogramma_pedissequum-GCA_910595825.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xanthogramma_pedissequum/GCA_910595825.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/geneset/2022_02/Xanthogramma_pedissequum-GCA_910595825.1-2022_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1/genome/Xanthogramma_pedissequum-GCA_910595825.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xanthogramma_pedissequum/GCA_910595825.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Xanthogramma_pedissequum/GCA_910595825.1
   rapid_link: https://rapid.ensembl.org/Xanthogramma_pedissequum_gca910595825v1/Info/Index
   alternate: https://rapid.ensembl.org/Xanthogramma_pedissequum_GCA_910595765.1/Info/Index
 
@@ -2981,43 +2981,43 @@
   image: Lepidoptera.png
   accession: GCA_905147715.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/genome/Xestia_xanthographa-GCA_905147715.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xestia_xanthographa/GCA_905147715.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/geneset/2021_11/Xestia_xanthographa-GCA_905147715.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1/genome/Xestia_xanthographa-GCA_905147715.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xestia_xanthographa/GCA_905147715.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.1
   rapid_link: https://rapid.ensembl.org/Xestia_xanthographa_gca905147715v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/xestia_xanthographa_GCA_905147715.1/xestia_xanthographa_gca905147715v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/xestia_xanthographa_GCA_905147715.1/xestia_xanthographa_gca905147715v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Xestia_xanthographa_GCA_905147755.1/Info/Index
 
 - species: Xestia xanthographa
   image: Lepidoptera.png
   accession: GCA_905147715.2
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/genome/Xestia_xanthographa-GCA_905147715.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xestia_xanthographa/GCA_905147715.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/geneset/2022_01/Xestia_xanthographa-GCA_905147715.2-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2/genome/Xestia_xanthographa-GCA_905147715.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xestia_xanthographa/GCA_905147715.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Xestia_xanthographa/GCA_905147715.2
   rapid_link: https://rapid.ensembl.org/Xestia_xanthographa_gca905147715v2/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/xestia_xanthographa_GCA_905147715.2/xestia_xanthographa_gca905147715v2_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/xestia_xanthographa_GCA_905147715.2/xestia_xanthographa_gca905147715v2_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Xestia_xanthographa_GCA_905147755.2/Info/Index
 
 - species: Xylota sylvarum
   image: Arthropods.png
   accession: GCA_905220385.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/genome/Xylota_sylvarum-GCA_905220385.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xylota_sylvarum/GCA_905220385.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/geneset/2021_12/Xylota_sylvarum-GCA_905220385.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1/genome/Xylota_sylvarum-GCA_905220385.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/xylota_sylvarum/GCA_905220385.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Xylota_sylvarum/GCA_905220385.1
   rapid_link: https://rapid.ensembl.org/Xylota_sylvarum_gca905220385v1/Info/Index
   alternate: https://rapid.ensembl.org/Xylota_sylvarum_GCA_905220405.1/Info/Index
 
@@ -3025,13 +3025,13 @@
   image: Lepidoptera.png
   accession: GCA_910592155.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/genome/Ypsolopha_scabrella-GCA_910592155.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ypsolopha_scabrella/GCA_910592155.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/geneset/2021_12/Ypsolopha_scabrella-GCA_910592155.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1/genome/Ypsolopha_scabrella-GCA_910592155.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ypsolopha_scabrella/GCA_910592155.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ypsolopha_scabrella/GCA_910592155.1
   rapid_link: https://rapid.ensembl.org/Ypsolopha_scabrella_gca910592155v1/Info/Index
   alternate: https://rapid.ensembl.org/Ypsolopha_scabrella_GCA_910591985.1/Info/Index
 
@@ -3039,13 +3039,13 @@
   image: Lepidoptera.png
   accession: GCA_907165235.1
   annotation_method: BRAKER2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/genome/Zeuzera_pyrina-GCA_907165235.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zeuzera_pyrina/GCA_907165235.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/geneset/2021_12/Zeuzera_pyrina-GCA_907165235.1-2021_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1/genome/Zeuzera_pyrina-GCA_907165235.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zeuzera_pyrina/GCA_907165235.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Zeuzera_pyrina/GCA_907165235.1
   rapid_link: https://rapid.ensembl.org/Zeuzera_pyrina_gca907165235v1/Info/Index
   alternate: https://rapid.ensembl.org/Zeuzera_pyrina_GCA_907165255.1/Info/Index
 
@@ -3053,14 +3053,14 @@
   image: Lepidoptera.png
   accession: GCA_907165275.1
   annotation_method: Ensembl Genebuild
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/genome/Zygaena_filipendulae-GCA_907165275.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zygaena_filipendulae/GCA_907165275.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/geneset/2021_11/Zygaena_filipendulae-GCA_907165275.1-2021_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1/genome/Zygaena_filipendulae-GCA_907165275.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zygaena_filipendulae/GCA_907165275.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Zygaena_filipendulae/GCA_907165275.1
   rapid_link: https://rapid.ensembl.org/Zygaena_filipendulae_gca907165275v1/Info/Index
-  busco_score: http://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/zygaena_filipendulae_GCA_907165275.1/zygaena_filipendulae_gca907165275v1_busco_short_summary.txt
+  busco_score: https://ftp.ebi.ac.uk/pub/databases/ensembl/dtol/busco_scores/zygaena_filipendulae_GCA_907165275.1/zygaena_filipendulae_gca907165275v1_busco_short_summary.txt
   alternate: https://rapid.ensembl.org/Zygaena_filipendulae_GCA_907165265.1/Info/Index
 

--- a/scripts/projects_page/geneswitch_species.yaml
+++ b/scripts/projects_page/geneswitch_species.yaml
@@ -1,13 +1,13 @@
 - species: Sus scrofa (pig - e102)
   submitted_by: The Swine Genome Sequencing Consortium (SGSC)
   accession: GCA_000003025.6
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa/Sus_scrofa.Sscrofa11.1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa/Sus_scrofa.Sscrofa11.1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa/pep/Sus_scrofa.Sscrofa11.1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa/cdna/Sus_scrofa.Sscrofa11.1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa/dna/Sus_scrofa.Sscrofa11.1.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sus_scrofa/GCA_000003025.6.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa/Sus_scrofa.Sscrofa11.1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa/Sus_scrofa.Sscrofa11.1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa/pep/Sus_scrofa.Sscrofa11.1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa/cdna/Sus_scrofa.Sscrofa11.1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa/dna/Sus_scrofa.Sscrofa11.1.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sus_scrofa/GCA_000003025.6.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (pig - e107)
@@ -18,20 +18,20 @@
   proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sus_scrofa/GCA_000003025.6/geneset/2022_02/Sus_scrofa-GCA_000003025.6-2022_02-pep.fa.gz
   transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sus_scrofa/GCA_000003025.6/geneset/2022_02/Sus_scrofa-GCA_000003025.6-2022_02-cdna.fa.gz
   softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sus_scrofa/GCA_000003025.6/genome/Sus_scrofa-GCA_000003025.6-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sus_scrofa/GCA_000003025.6.repeatmodeler.fa
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sus_scrofa/GCA_000003025.6.repeatmodeler.fa
   ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sus_scrofa/GCA_000003025.6/
   rapid_link: https://rapid.ensembl.org/Sus_scrofa_GCA_000003025.6/Info/Index
 
 - species: Gallus gallus (broiler - e102)
   submitted_by: Genome Reference Consortium
   accession: GCA_000002315.5
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/gallus_gallus/Gallus_gallus.GRCg6a.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/gallus_gallus/Gallus_gallus.GRCg6a.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/gallus_gallus/pep/Gallus_gallus.GRCg6a.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/gallus_gallus/cdna/Gallus_gallus.GRCg6a.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/gallus_gallus/dna/Gallus_gallus.GRCg6a.dna_sm.toplevel.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_000002315.5.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/gallus_gallus/Gallus_gallus.GRCg6a.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/gallus_gallus/Gallus_gallus.GRCg6a.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/gallus_gallus/pep/Gallus_gallus.GRCg6a.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/gallus_gallus/cdna/Gallus_gallus.GRCg6a.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/gallus_gallus/dna/Gallus_gallus.GRCg6a.dna_sm.toplevel.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_000002315.5.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Gallus_gallus/Info/Index
 
 - species: Gallus gallus (jungle fowl - e107)
@@ -42,7 +42,7 @@
   proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_000002315.5/geneset/2022_01/Gallus_gallus-GCA_000002315.5-2022_01-pep.fa.gz
   transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_000002315.5/geneset/2022_01/Gallus_gallus-GCA_000002315.5-2022_01-cdna.fa.gz
   softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_000002315.5/genome/Gallus_gallus-GCA_000002315.5-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_000002315.5.repeatmodeler.fa
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_000002315.5.repeatmodeler.fa
   ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_000002315.5/
   rapid_link: https://rapid.ensembl.org/Gallus_gallus_GCA_000002315.5/Info/Index
 
@@ -54,7 +54,7 @@
   proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-pep.fa.gz
   transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-cdna.fa.gz
   softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/genome/Gallus_gallus-GCA_016699485.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_016699485.1.repeatmodeler.fa
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_016699485.1.repeatmodeler.fa
   ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/
   rapid_link: https://rapid.ensembl.org/Gallus_gallus_GCA_016699485.1/Info/Index
 
@@ -72,132 +72,132 @@
 - species: Sus scrofa (bamei - e102)
   submitted_by: Novogene
   accession: GCA_001700235.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_bamei/Sus_scrofa_bamei.Bamei_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_bamei/Sus_scrofa_bamei.Bamei_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_bamei/pep/Sus_scrofa_bamei.Bamei_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_bamei/cdna/Sus_scrofa_bamei.Bamei_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_bamei/dna/Sus_scrofa_bamei.Bamei_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_bamei/Sus_scrofa_bamei.Bamei_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_bamei/Sus_scrofa_bamei.Bamei_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_bamei/pep/Sus_scrofa_bamei.Bamei_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_bamei/cdna/Sus_scrofa_bamei.Bamei_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_bamei/dna/Sus_scrofa_bamei.Bamei_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (berkshire - e102)
   submitted_by: Novogene
   accession: GCA_001700575.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_berkshire/Sus_scrofa_berkshire.Berkshire_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_berkshire/Sus_scrofa_berkshire.Berkshire_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_berkshire/pep/Sus_scrofa_berkshire.Berkshire_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_berkshire/cdna/Sus_scrofa_berkshire.Berkshire_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_berkshire/dna/Sus_scrofa_berkshire.Berkshire_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_berkshire/Sus_scrofa_berkshire.Berkshire_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_berkshire/Sus_scrofa_berkshire.Berkshire_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_berkshire/pep/Sus_scrofa_berkshire.Berkshire_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_berkshire/cdna/Sus_scrofa_berkshire.Berkshire_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_berkshire/dna/Sus_scrofa_berkshire.Berkshire_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (hampshire - e102)
   submitted_by: Novogene
   accession: GCA_001700165.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_hampshire/Sus_scrofa_hampshire.Hampshire_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_hampshire/Sus_scrofa_hampshire.Hampshire_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_hampshire/pep/Sus_scrofa_hampshire.Hampshire_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_hampshire/cdna/Sus_scrofa_hampshire.Hampshire_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_hampshire/dna/Sus_scrofa_hampshire.Hampshire_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_hampshire/Sus_scrofa_hampshire.Hampshire_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_hampshire/Sus_scrofa_hampshire.Hampshire_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_hampshire/pep/Sus_scrofa_hampshire.Hampshire_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_hampshire/cdna/Sus_scrofa_hampshire.Hampshire_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_hampshire/dna/Sus_scrofa_hampshire.Hampshire_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (jinhua - e102)
   submitted_by: Novogene
   accession: GCA_001700295.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_jinhua/Sus_scrofa_jinhua.Jinhua_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_jinhua/Sus_scrofa_jinhua.Jinhua_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_jinhua/pep/Sus_scrofa_jinhua.Jinhua_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_jinhua/cdna/Sus_scrofa_jinhua.Jinhua_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_jinhua/dna/Sus_scrofa_jinhua.Jinhua_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_jinhua/Sus_scrofa_jinhua.Jinhua_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_jinhua/Sus_scrofa_jinhua.Jinhua_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_jinhua/pep/Sus_scrofa_jinhua.Jinhua_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_jinhua/cdna/Sus_scrofa_jinhua.Jinhua_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_jinhua/dna/Sus_scrofa_jinhua.Jinhua_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (landrace - e102)
   submitted_by: Novogene
   accession: GCA_001700215.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_landrace/Sus_scrofa_landrace.Landrace_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_landrace/Sus_scrofa_landrace.Landrace_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_landrace/pep/Sus_scrofa_landrace.Landrace_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_landrace/cdna/Sus_scrofa_landrace.Landrace_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_landrace/dna/Sus_scrofa_landrace.Landrace_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_landrace/Sus_scrofa_landrace.Landrace_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_landrace/Sus_scrofa_landrace.Landrace_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_landrace/pep/Sus_scrofa_landrace.Landrace_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_landrace/cdna/Sus_scrofa_landrace.Landrace_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_landrace/dna/Sus_scrofa_landrace.Landrace_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (largewhite - e102)
   submitted_by: Novogene
   accession: GCA_001700135.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_largewhite/Sus_scrofa_largewhite.Large_White_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_largewhite/Sus_scrofa_largewhite.Large_White_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_largewhite/pep/Sus_scrofa_largewhite.Large_White_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_largewhite/cdna/Sus_scrofa_largewhite.Large_White_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_largewhite/dna/Sus_scrofa_largewhite.Large_White_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_largewhite/Sus_scrofa_largewhite.Large_White_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_largewhite/Sus_scrofa_largewhite.Large_White_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_largewhite/pep/Sus_scrofa_largewhite.Large_White_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_largewhite/cdna/Sus_scrofa_largewhite.Large_White_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_largewhite/dna/Sus_scrofa_largewhite.Large_White_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (meishan - e102)
   submitted_by: Novogene
   accession: GCA_001700195.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_meishan/Sus_scrofa_meishan.Meishan_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_meishan/Sus_scrofa_meishan.Meishan_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_meishan/pep/Sus_scrofa_meishan.Meishan_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_meishan/cdna/Sus_scrofa_meishan.Meishan_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_meishan/dna/Sus_scrofa_meishan.Meishan_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_meishan/Sus_scrofa_meishan.Meishan_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_meishan/Sus_scrofa_meishan.Meishan_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_meishan/pep/Sus_scrofa_meishan.Meishan_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_meishan/cdna/Sus_scrofa_meishan.Meishan_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_meishan/dna/Sus_scrofa_meishan.Meishan_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (pietrain - e102)
   submitted_by: Novogene
   accession: GCA_001700255.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_pietrain/Sus_scrofa_pietrain.Pietrain_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_pietrain/Sus_scrofa_pietrain.Pietrain_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_pietrain/pep/Sus_scrofa_pietrain.Pietrain_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_pietrain/cdna/Sus_scrofa_pietrain.Pietrain_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_pietrain/dna/Sus_scrofa_pietrain.Pietrain_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_pietrain/Sus_scrofa_pietrain.Pietrain_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_pietrain/Sus_scrofa_pietrain.Pietrain_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_pietrain/pep/Sus_scrofa_pietrain.Pietrain_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_pietrain/cdna/Sus_scrofa_pietrain.Pietrain_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_pietrain/dna/Sus_scrofa_pietrain.Pietrain_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (rongchang - e102)
   submitted_by: Novogene
   accession: GCA_001700155.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_rongchang/Sus_scrofa_rongchang.Rongchang_pig_v1.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_rongchang/Sus_scrofa_rongchang.Rongchang_pig_v1.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_rongchang/pep/Sus_scrofa_rongchang.Rongchang_pig_v1.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_rongchang/cdna/Sus_scrofa_rongchang.Rongchang_pig_v1.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_rongchang/dna/Sus_scrofa_rongchang.Rongchang_pig_v1.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_rongchang/Sus_scrofa_rongchang.Rongchang_pig_v1.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_rongchang/Sus_scrofa_rongchang.Rongchang_pig_v1.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_rongchang/pep/Sus_scrofa_rongchang.Rongchang_pig_v1.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_rongchang/cdna/Sus_scrofa_rongchang.Rongchang_pig_v1.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_rongchang/dna/Sus_scrofa_rongchang.Rongchang_pig_v1.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (tibetan - e102)
   submitted_by: Novogene
   accession: GCA_000472085.2
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_tibetan/Sus_scrofa_tibetan.Tibetan_Pig_v2.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_tibetan/Sus_scrofa_tibetan.Tibetan_Pig_v2.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_tibetan/pep/Sus_scrofa_tibetan.Tibetan_Pig_v2.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_tibetan/cdna/Sus_scrofa_tibetan.Tibetan_Pig_v2.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_tibetan/dna/Sus_scrofa_tibetan.Tibetan_Pig_v2.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_tibetan/Sus_scrofa_tibetan.Tibetan_Pig_v2.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_tibetan/Sus_scrofa_tibetan.Tibetan_Pig_v2.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_tibetan/pep/Sus_scrofa_tibetan.Tibetan_Pig_v2.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_tibetan/cdna/Sus_scrofa_tibetan.Tibetan_Pig_v2.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_tibetan/dna/Sus_scrofa_tibetan.Tibetan_Pig_v2.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (usmarc - e102)
   submitted_by: USDA ARS
   accession: GCA_002844635.1
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_usmarc/Sus_scrofa_usmarc.USMARCv1.0.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_usmarc/Sus_scrofa_usmarc.USMARCv1.0.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_usmarc/pep/Sus_scrofa_usmarc.USMARCv1.0.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_usmarc/cdna/Sus_scrofa_usmarc.USMARCv1.0.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_usmarc/dna/Sus_scrofa_usmarc.USMARCv1.0.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_usmarc/Sus_scrofa_usmarc.USMARCv1.0.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_usmarc/Sus_scrofa_usmarc.USMARCv1.0.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_usmarc/pep/Sus_scrofa_usmarc.USMARCv1.0.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_usmarc/cdna/Sus_scrofa_usmarc.USMARCv1.0.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_usmarc/dna/Sus_scrofa_usmarc.USMARCv1.0.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 
 - species: Sus scrofa (wuzhishan - e102)
   submitted_by: BGI-shenzhen
   accession: GCA_000325925.2
-  annotation_gtf: http://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_wuzhishan/Sus_scrofa_wuzhishan.minipig_v1.0.102.gtf.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_wuzhishan/Sus_scrofa_wuzhishan.minipig_v1.0.102.gff3.gz
-  proteins: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_wuzhishan/pep/Sus_scrofa_wuzhishan.minipig_v1.0.pep.all.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_wuzhishan/cdna/Sus_scrofa_wuzhishan.minipig_v1.0.cdna.all.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_wuzhishan/dna/Sus_scrofa_wuzhishan.minipig_v1.0.dna_sm.toplevel.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/release-102
+  annotation_gtf: https://ftp.ensembl.org/pub/release-102/gtf/sus_scrofa_wuzhishan/Sus_scrofa_wuzhishan.minipig_v1.0.102.gtf.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/release-102/gff3/sus_scrofa_wuzhishan/Sus_scrofa_wuzhishan.minipig_v1.0.102.gff3.gz
+  proteins: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_wuzhishan/pep/Sus_scrofa_wuzhishan.minipig_v1.0.pep.all.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_wuzhishan/cdna/Sus_scrofa_wuzhishan.minipig_v1.0.cdna.all.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/release-102/fasta/sus_scrofa_wuzhishan/dna/Sus_scrofa_wuzhishan.minipig_v1.0.dna_sm.toplevel.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/release-102
   ensembl_link: https://e102.ensembl.org/Sus_scrofa/Info/Index
 

--- a/scripts/projects_page/vgp_species.yaml
+++ b/scripts/projects_page/vgp_species.yaml
@@ -1,910 +1,910 @@
 - species: Acanthopagrus latus
   image: Fish.png
   accession: GCA_904848185.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/genome/Acanthopagrus_latus-GCA_904848185.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/acanthopagrus_latus/GCA_904848185.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/geneset/2022_03/Acanthopagrus_latus-GCA_904848185.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1/genome/Acanthopagrus_latus-GCA_904848185.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/acanthopagrus_latus/GCA_904848185.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Acanthopagrus_latus/GCA_904848185.1
   rapid_link: https://rapid.ensembl.org/Acanthopagrus_latus_gca904848185v1/Info/Index
 
 - species: Acipenser ruthenus
   image: Fish.png
   accession: GCA_902713435.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/genome/Acipenser_ruthenus-GCA_902713435.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/acipenser_ruthenus/GCA_902713435.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/geneset/2020_06/Acipenser_ruthenus-GCA_902713435.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1/genome/Acipenser_ruthenus-GCA_902713435.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/acipenser_ruthenus/GCA_902713435.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Acipenser_ruthenus/GCA_902713435.1
   rapid_link: https://rapid.ensembl.org/Acipenser_ruthenus/Info/Index
 
 - species: Amblyraja radiata
   image: Chordates.png
   accession: GCA_010909765.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/genome/Amblyraja_radiata-GCA_010909765.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amblyraja_radiata/GCA_010909765.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/geneset/2020_06/Amblyraja_radiata-GCA_010909765.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1/genome/Amblyraja_radiata-GCA_010909765.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/amblyraja_radiata/GCA_010909765.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Amblyraja_radiata/GCA_010909765.1
   rapid_link: https://rapid.ensembl.org/Amblyraja_radiata/Info/Index
 
 - species: Anabas testudineus
   image: Fish.png
   accession: GCA_900324465.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/genome/Anabas_testudineus-GCA_900324465.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anabas_testudineus/GCA_900324465.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/geneset/2020_06/Anabas_testudineus-GCA_900324465.2-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2/genome/Anabas_testudineus-GCA_900324465.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anabas_testudineus/GCA_900324465.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.2
   ensembl_link: https://www.ensembl.org/Anabas_testudineus/Info/Index
 
 - species: Anabas testudineus
   image: Fish.png
   accession: GCA_900324465.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/genome/Anabas_testudineus-GCA_900324465.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anabas_testudineus/GCA_900324465.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/geneset/2018_07/Anabas_testudineus-GCA_900324465.1-2018_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1/genome/Anabas_testudineus-GCA_900324465.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anabas_testudineus/GCA_900324465.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Anabas_testudineus/GCA_900324465.1
   rapid_link: https://rapid.ensembl.org/Anabas_testudineus_gca900324465v1/Info/Index
 
 - species: Anableps anableps
   image: Fish.png
   accession: GCA_014839685.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/genome/Anableps_anableps-GCA_014839685.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anableps_anableps/GCA_014839685.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/geneset/2021_04/Anableps_anableps-GCA_014839685.1-2021_04-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1/genome/Anableps_anableps-GCA_014839685.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anableps_anableps/GCA_014839685.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Anableps_anableps/GCA_014839685.1
   rapid_link: https://rapid.ensembl.org/Anableps_anableps_gca014839685v1/Info/Index
 
 - species: Anguilla anguilla
   image: Fish.png
   accession: GCA_013347855.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/genome/Anguilla_anguilla-GCA_013347855.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anguilla_anguilla/GCA_013347855.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/geneset/2020_08/Anguilla_anguilla-GCA_013347855.1-2020_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1/genome/Anguilla_anguilla-GCA_013347855.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/anguilla_anguilla/GCA_013347855.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Anguilla_anguilla/GCA_013347855.1
   rapid_link: https://rapid.ensembl.org/Anguilla_anguilla/Info/Index
 
 - species: Aquila chrysaetos chrysaetos
   image: Birds.png
   accession: GCA_900496995.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/genome/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aquila_chrysaetos_chrysaetos/GCA_900496995.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/geneset/2019_07/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-2019_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2/genome/Aquila_chrysaetos_chrysaetos-GCA_900496995.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/aquila_chrysaetos_chrysaetos/GCA_900496995.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Aquila_chrysaetos_chrysaetos/GCA_900496995.2
   ensembl_link: https://www.ensembl.org/Aquila_chrysaetos_chrysaetos/Info/Index
 
 - species: Archocentrus centrarchus
   image: Fish.png
   accession: GCA_007364275.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/genome/Archocentrus_centrarchus-GCA_007364275.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/archocentrus_centrarchus/GCA_007364275.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/geneset/2020_04/Archocentrus_centrarchus-GCA_007364275.2-2020_04-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2/genome/Archocentrus_centrarchus-GCA_007364275.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/archocentrus_centrarchus/GCA_007364275.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Archocentrus_centrarchus/GCA_007364275.2
   rapid_link: https://rapid.ensembl.org/Archocentrus_centrarchus/Info/Index
 
 - species: Arvicanthis niloticus
   image: Mammals.png
   accession: GCA_011762505.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/genome/Arvicanthis_niloticus-GCA_011762505.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/arvicanthis_niloticus/GCA_011762505.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/geneset/2020_06/Arvicanthis_niloticus-GCA_011762505.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1/genome/Arvicanthis_niloticus-GCA_011762505.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/arvicanthis_niloticus/GCA_011762505.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Arvicanthis_niloticus/GCA_011762505.1
   rapid_link: https://rapid.ensembl.org/Arvicanthis_niloticus/Info/Index
 
 - species: Astatotilapia calliptera
   image: Fish.png
   accession: GCA_900246225.3
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/genome/Astatotilapia_calliptera-GCA_900246225.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/astatotilapia_calliptera/GCA_900246225.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/geneset/2018_07/Astatotilapia_calliptera-GCA_900246225.3-2018_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3/genome/Astatotilapia_calliptera-GCA_900246225.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/astatotilapia_calliptera/GCA_900246225.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Astatotilapia_calliptera/GCA_900246225.3
   ensembl_link: https://www.ensembl.org/Astatotilapia_calliptera/Info/Index
 
 - species: Balaenoptera musculus
   image: Mammals.png
   accession: GCA_009873245.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/genome/Balaenoptera_musculus-GCA_009873245.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/balaenoptera_musculus/GCA_009873245.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/geneset/2020_02/Balaenoptera_musculus-GCA_009873245.2-2020_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2/genome/Balaenoptera_musculus-GCA_009873245.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/balaenoptera_musculus/GCA_009873245.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.2
   ensembl_link: https://www.ensembl.org/Balaenoptera_musculus/Info/Index
 
 - species: Balaenoptera musculus
   image: Mammals.png
   accession: GCA_009873245.3
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/genome/Balaenoptera_musculus-GCA_009873245.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/balaenoptera_musculus/GCA_009873245.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/geneset/2020_12/Balaenoptera_musculus-GCA_009873245.3-2020_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3/genome/Balaenoptera_musculus-GCA_009873245.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/balaenoptera_musculus/GCA_009873245.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Balaenoptera_musculus/GCA_009873245.3
   rapid_link: https://rapid.ensembl.org/Balaenoptera_musculus_gca009873245v3/Info/Index
 
 - species: Betta splendens
   image: Fish.png
   accession: GCA_900634795.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/genome/Betta_splendens-GCA_900634795.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/betta_splendens/GCA_900634795.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/geneset/2019_06/Betta_splendens-GCA_900634795.2-2019_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2/genome/Betta_splendens-GCA_900634795.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/betta_splendens/GCA_900634795.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Betta_splendens/GCA_900634795.2
   ensembl_link: https://www.ensembl.org/Betta_splendens/Info/Index
 
 - species: Callithrix jacchus
   image: Mammals.png
   accession: GCA_011100555.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/genome/Callithrix_jacchus-GCA_011100555.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/callithrix_jacchus/GCA_011100555.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/geneset/2020_11/Callithrix_jacchus-GCA_011100555.1-2020_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1/genome/Callithrix_jacchus-GCA_011100555.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/callithrix_jacchus/GCA_011100555.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Callithrix_jacchus/GCA_011100555.1
   ensembl_link: https://www.ensembl.org/Callithrix_jacchus/Info/Index
 
 - species: Carcharodon carcharias
   image: Chordates.png
   accession: GCA_017639515.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/genome/Carcharodon_carcharias-GCA_017639515.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/carcharodon_carcharias/GCA_017639515.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/geneset/2021_10/Carcharodon_carcharias-GCA_017639515.1-2021_10-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1/genome/Carcharodon_carcharias-GCA_017639515.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/carcharodon_carcharias/GCA_017639515.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Carcharodon_carcharias/GCA_017639515.1
   rapid_link: https://rapid.ensembl.org/Carcharodon_carcharias_gca017639515v1/Info/Index
 
 - species: Catharus ustulatus
   image: Birds.png
   accession: GCA_009819885.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/genome/Catharus_ustulatus-GCA_009819885.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/catharus_ustulatus/GCA_009819885.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/geneset/2020_03/Catharus_ustulatus-GCA_009819885.1-2020_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1/genome/Catharus_ustulatus-GCA_009819885.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/catharus_ustulatus/GCA_009819885.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Catharus_ustulatus/GCA_009819885.1
   ensembl_link: https://www.ensembl.org/Catharus_ustulatus/Info/Index
 
 - species: Chelmon rostratus
   image: Fish.png
   accession: GCA_017976325.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/genome/Chelmon_rostratus-GCA_017976325.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chelmon_rostratus/GCA_017976325.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/geneset/2022_03/Chelmon_rostratus-GCA_017976325.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1/genome/Chelmon_rostratus-GCA_017976325.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chelmon_rostratus/GCA_017976325.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Chelmon_rostratus/GCA_017976325.1
   rapid_link: https://rapid.ensembl.org/Chelmon_rostratus_gca017976325v1/Info/Index
 
 - species: Chiroxiphia lanceolata
   image: Birds.png
   accession: GCA_009829145.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/genome/Chiroxiphia_lanceolata-GCA_009829145.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chiroxiphia_lanceolata/GCA_009829145.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/geneset/2020_11/Chiroxiphia_lanceolata-GCA_009829145.1-2020_11-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1/genome/Chiroxiphia_lanceolata-GCA_009829145.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/chiroxiphia_lanceolata/GCA_009829145.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Chiroxiphia_lanceolata/GCA_009829145.1
   rapid_link: https://rapid.ensembl.org/Chiroxiphia_lanceolata_gca009829145v1/Info/Index
 
 - species: Choloepus didactylus
   image: Mammals.png
   accession: GCA_015220235.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/genome/Choloepus_didactylus-GCA_015220235.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/choloepus_didactylus/GCA_015220235.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/geneset/2021_02/Choloepus_didactylus-GCA_015220235.1-2021_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1/genome/Choloepus_didactylus-GCA_015220235.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/choloepus_didactylus/GCA_015220235.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Choloepus_didactylus/GCA_015220235.1
   rapid_link: https://rapid.ensembl.org/Choloepus_didactylus_gca015220235v1/Info/Index
 
 - species: Corvus moneduloides
   image: Birds.png
   accession: GCA_009650955.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/genome/Corvus_moneduloides-GCA_009650955.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/corvus_moneduloides/GCA_009650955.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/geneset/2020_08/Corvus_moneduloides-GCA_009650955.1-2020_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1/genome/Corvus_moneduloides-GCA_009650955.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/corvus_moneduloides/GCA_009650955.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Corvus_moneduloides/GCA_009650955.1
   rapid_link: https://rapid.ensembl.org/Corvus_moneduloides_gca009650955v1/Info/Index
 
 - species: Cottoperca gobio
   image: Fish.png
   accession: GCA_900634415.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/genome/Cottoperca_gobio-GCA_900634415.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cottoperca_gobio/GCA_900634415.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/geneset/2019_04/Cottoperca_gobio-GCA_900634415.1-2019_04-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1/genome/Cottoperca_gobio-GCA_900634415.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cottoperca_gobio/GCA_900634415.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cottoperca_gobio/GCA_900634415.1
   ensembl_link: https://www.ensembl.org/Cottoperca_gobio/Info/Index
 
 - species: Cyclopterus lumpus
   image: Fish.png
   accession: GCA_009769545.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/genome/Cyclopterus_lumpus-GCA_009769545.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyclopterus_lumpus/GCA_009769545.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/geneset/2020_02/Cyclopterus_lumpus-GCA_009769545.1-2020_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1/genome/Cyclopterus_lumpus-GCA_009769545.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cyclopterus_lumpus/GCA_009769545.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cyclopterus_lumpus/GCA_009769545.1
   ensembl_link: https://www.ensembl.org/Cyclopterus_lumpus/Info/Index
 
 - species: Cygnus olor
   image: Birds.png
   accession: GCA_009769625.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/genome/Cygnus_olor-GCA_009769625.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cygnus_olor/GCA_009769625.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/geneset/2021_09/Cygnus_olor-GCA_009769625.2-2021_09-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2/genome/Cygnus_olor-GCA_009769625.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/cygnus_olor/GCA_009769625.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Cygnus_olor/GCA_009769625.2
   rapid_link: https://rapid.ensembl.org/Cygnus_olor_gca009769625v2/Info/Index
 
 - species: Denticeps clupeoides
   image: Fish.png
   accession: GCA_900700375.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/genome/Denticeps_clupeoides-GCA_900700375.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/denticeps_clupeoides/GCA_900700375.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/geneset/2019_12/Denticeps_clupeoides-GCA_900700375.1-2019_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1/genome/Denticeps_clupeoides-GCA_900700375.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/denticeps_clupeoides/GCA_900700375.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.1
   ensembl_link: https://www.ensembl.org/Denticeps_clupeoides/Info/Index
 
 - species: Denticeps clupeoides
   image: Fish.png
   accession: GCA_900700375.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/genome/Denticeps_clupeoides-GCA_900700375.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/denticeps_clupeoides/GCA_900700375.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/geneset/2020_09/Denticeps_clupeoides-GCA_900700375.2-2020_09-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2/genome/Denticeps_clupeoides-GCA_900700375.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/denticeps_clupeoides/GCA_900700375.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Denticeps_clupeoides/GCA_900700375.2
   rapid_link: https://rapid.ensembl.org/Denticeps_clupeoides_gca900700375v2/Info/Index
 
 - species: Echeneis naucrates
   image: Fish.png
   accession: GCA_900963305.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/genome/Echeneis_naucrates-GCA_900963305.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/echeneis_naucrates/GCA_900963305.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/geneset/2019_08/Echeneis_naucrates-GCA_900963305.1-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1/genome/Echeneis_naucrates-GCA_900963305.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/echeneis_naucrates/GCA_900963305.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Echeneis_naucrates/GCA_900963305.1
   ensembl_link: https://www.ensembl.org/Echeneis_naucrates/Info/Index
 
 - species: Electrophorus electricus
   image: Fish.png
   accession: GCA_013358815.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/genome/Electrophorus_electricus-GCA_013358815.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/electrophorus_electricus/GCA_013358815.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/geneset/2020_08/Electrophorus_electricus-GCA_013358815.1-2020_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1/genome/Electrophorus_electricus-GCA_013358815.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/electrophorus_electricus/GCA_013358815.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Electrophorus_electricus/GCA_013358815.1
   rapid_link: https://rapid.ensembl.org/Electrophorus_electricus/Info/Index
 
 - species: Erpetoichthys calabaricus
   image: Fish.png
   accession: GCA_900747795.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/genome/Erpetoichthys_calabaricus-GCA_900747795.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erpetoichthys_calabaricus/GCA_900747795.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/geneset/2019_05/Erpetoichthys_calabaricus-GCA_900747795.2-2019_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2/genome/Erpetoichthys_calabaricus-GCA_900747795.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/erpetoichthys_calabaricus/GCA_900747795.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Erpetoichthys_calabaricus/GCA_900747795.2
   ensembl_link: https://www.ensembl.org/Erpetoichthys_calabaricus/Info/Index
 
 - species: Gadus morhua
   image: Fish.png
   accession: GCA_902167405.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/genome/Gadus_morhua-GCA_902167405.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gadus_morhua/GCA_902167405.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/geneset/2020_06/Gadus_morhua-GCA_902167405.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1/genome/Gadus_morhua-GCA_902167405.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gadus_morhua/GCA_902167405.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gadus_morhua/GCA_902167405.1
   ensembl_link: https://www.ensembl.org/Gadus_morhua/Info/Index
 
 - species: Gallus gallus (maternal broiler)
   image: Birds.png
   accession: GCA_016699485.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/genome/Gallus_gallus-GCA_016699485.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_016699485.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/geneset/2022_01/Gallus_gallus-GCA_016699485.1-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1/genome/Gallus_gallus-GCA_016699485.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gallus_gallus/GCA_016699485.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gallus_gallus/GCA_016699485.1
   rapid_link: https://rapid.ensembl.org/Gallus_gallus_gca016699485v1/Info/Index
 
 - species: Gopherus evgoodei
   image: Reptiles.png
   accession: GCA_007399415.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/genome/Gopherus_evgoodei-GCA_007399415.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gopherus_evgoodei/GCA_007399415.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/geneset/2019_12/Gopherus_evgoodei-GCA_007399415.1-2019_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1/genome/Gopherus_evgoodei-GCA_007399415.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gopherus_evgoodei/GCA_007399415.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gopherus_evgoodei/GCA_007399415.1
   ensembl_link: https://www.ensembl.org/Gopherus_evgoodei/Info/Index
 
 - species: Gouania willdenowi
   image: Fish.png
   accession: GCA_900634775.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/genome/Gouania_willdenowi-GCA_900634775.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gouania_willdenowi/GCA_900634775.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/geneset/2019_05/Gouania_willdenowi-GCA_900634775.1-2019_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1/genome/Gouania_willdenowi-GCA_900634775.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gouania_willdenowi/GCA_900634775.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gouania_willdenowi/GCA_900634775.1
   ensembl_link: https://www.ensembl.org/Gouania_willdenowi/Info/Index
 
 - species: Gymnodraco acuticeps
   image: Fish.png
   accession: GCA_902827175.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/genome/Gymnodraco_acuticeps-GCA_902827175.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnodraco_acuticeps/GCA_902827175.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/geneset/2020_05/Gymnodraco_acuticeps-GCA_902827175.1-2020_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1/genome/Gymnodraco_acuticeps-GCA_902827175.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/gymnodraco_acuticeps/GCA_902827175.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Gymnodraco_acuticeps/GCA_902827175.1
   rapid_link: https://rapid.ensembl.org/Gymnodraco_acuticeps/Info/Index
 
 - species: Harpagifer antarcticus
   image: Fish.png
   accession: GCA_902827135.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/genome/Harpagifer_antarcticus-GCA_902827135.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/harpagifer_antarcticus/GCA_902827135.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/geneset/2020_07/Harpagifer_antarcticus-GCA_902827135.1-2020_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1/genome/Harpagifer_antarcticus-GCA_902827135.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/harpagifer_antarcticus/GCA_902827135.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Harpagifer_antarcticus/GCA_902827135.1
   rapid_link: https://rapid.ensembl.org/Harpagifer_antarcticus/Info/Index
 
 - species: Hippoglossus hippoglossus
   image: Fish.png
   accession: GCA_009819705.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/genome/Hippoglossus_hippoglossus-GCA_009819705.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hippoglossus_hippoglossus/GCA_009819705.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/geneset/2022_03/Hippoglossus_hippoglossus-GCA_009819705.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1/genome/Hippoglossus_hippoglossus-GCA_009819705.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/hippoglossus_hippoglossus/GCA_009819705.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hippoglossus_hippoglossus/GCA_009819705.1
   rapid_link: https://rapid.ensembl.org/Hippoglossus_hippoglossus_gca009819705v1/Info/Index
 
 - species: Hirundo rustica
   image: Birds.png
   accession: GCA_015227805.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/genome/Hirundo_rustica-GCA_015227805.1-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/geneset/2021_02/Hirundo_rustica-GCA_015227805.1-2021_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1/genome/Hirundo_rustica-GCA_015227805.1-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Hirundo_rustica/GCA_015227805.1
   rapid_link: https://rapid.ensembl.org/Hirundo_rustica_gca015227805v1/Info/Index
 
 - species: Lacerta agilis
   image: Chordates.png
   accession: GCA_009819535.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/genome/Lacerta_agilis-GCA_009819535.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lacerta_agilis/GCA_009819535.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/geneset/2021_03/Lacerta_agilis-GCA_009819535.1-2021_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1/genome/Lacerta_agilis-GCA_009819535.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lacerta_agilis/GCA_009819535.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lacerta_agilis/GCA_009819535.1
   rapid_link: https://rapid.ensembl.org/Lacerta_agilis_gca009819535v1/Info/Index
 
 - species: Lynx canadensis
   image: Mammals.png
   accession: GCA_007474595.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/genome/Lynx_canadensis-GCA_007474595.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lynx_canadensis/GCA_007474595.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/geneset/2019_08/Lynx_canadensis-GCA_007474595.1-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1/genome/Lynx_canadensis-GCA_007474595.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/lynx_canadensis/GCA_007474595.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Lynx_canadensis/GCA_007474595.1
   ensembl_link: https://www.ensembl.org/Lynx_canadensis/Info/Index
 
 - species: Mastacembelus armatus
   image: Fish.png
   accession: GCA_900324485.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/genome/Mastacembelus_armatus-GCA_900324485.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mastacembelus_armatus/GCA_900324485.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/geneset/2020_04/Mastacembelus_armatus-GCA_900324485.2-2020_04-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2/genome/Mastacembelus_armatus-GCA_900324485.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mastacembelus_armatus/GCA_900324485.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.2
   ensembl_link: https://www.ensembl.org/Mastacembelus_armatus/Info/Index
 
 - species: Mastacembelus armatus
   image: Fish.png
   accession: GCA_900324485.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/genome/Mastacembelus_armatus-GCA_900324485.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mastacembelus_armatus/GCA_900324485.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/geneset/2018_07/Mastacembelus_armatus-GCA_900324485.1-2018_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1/genome/Mastacembelus_armatus-GCA_900324485.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mastacembelus_armatus/GCA_900324485.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mastacembelus_armatus/GCA_900324485.1
   rapid_link: https://rapid.ensembl.org/Mastacembelus_armatus_gca900324485v1/Info/Index
 
 - species: Megalops cyprinoides
   image: Fish.png
   accession: GCA_013368585.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/genome/Megalops_cyprinoides-GCA_013368585.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/megalops_cyprinoides/GCA_013368585.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/geneset/2020_07/Megalops_cyprinoides-GCA_013368585.1-2020_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1/genome/Megalops_cyprinoides-GCA_013368585.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/megalops_cyprinoides/GCA_013368585.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Megalops_cyprinoides/GCA_013368585.1
   rapid_link: https://rapid.ensembl.org/Megalops_cyprinoides/Info/Index
 
 - species: Melopsittacus undulatus
   image: Birds.png
   accession: GCA_012275295.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/genome/Melopsittacus_undulatus-GCA_012275295.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melopsittacus_undulatus/GCA_012275295.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/geneset/2020_05/Melopsittacus_undulatus-GCA_012275295.1-2020_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1/genome/Melopsittacus_undulatus-GCA_012275295.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/melopsittacus_undulatus/GCA_012275295.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Melopsittacus_undulatus/GCA_012275295.1
   rapid_link: https://rapid.ensembl.org/Melopsittacus_undulatus/Info/Index
 
 - species: Mustela erminea
   image: Mammals.png
   accession: GCA_009829155.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/genome/Mustela_erminea-GCA_009829155.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mustela_erminea/GCA_009829155.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/geneset/2021_05/Mustela_erminea-GCA_009829155.1-2021_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1/genome/Mustela_erminea-GCA_009829155.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/mustela_erminea/GCA_009829155.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Mustela_erminea/GCA_009829155.1
   rapid_link: https://rapid.ensembl.org/Mustela_erminea_gca009829155v1/Info/Index
 
 - species: Myripristis murdjan
   image: Fish.png
   accession: GCA_902150065.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/genome/Myripristis_murdjan-GCA_902150065.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/myripristis_murdjan/GCA_902150065.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/geneset/2019_08/Myripristis_murdjan-GCA_902150065.1-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1/genome/Myripristis_murdjan-GCA_902150065.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/myripristis_murdjan/GCA_902150065.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Myripristis_murdjan/GCA_902150065.1
   ensembl_link: https://www.ensembl.org/Myripristis_murdjan/Info/Index
 
 - species: Notolabrus celidotus
   image: Fish.png
   accession: GCA_009762535.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/genome/Notolabrus_celidotus-GCA_009762535.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notolabrus_celidotus/GCA_009762535.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/geneset/2020_06/Notolabrus_celidotus-GCA_009762535.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1/genome/Notolabrus_celidotus-GCA_009762535.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/notolabrus_celidotus/GCA_009762535.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Notolabrus_celidotus/GCA_009762535.1
   rapid_link: https://rapid.ensembl.org/Notolabrus_celidotus/Info/Index
 
 - species: Ornithorhynchus anatinus
   image: Mammals.png
   accession: GCA_004115215.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/genome/Ornithorhynchus_anatinus-GCA_004115215.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ornithorhynchus_anatinus/GCA_004115215.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/geneset/2019_10/Ornithorhynchus_anatinus-GCA_004115215.2-2019_10-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2/genome/Ornithorhynchus_anatinus-GCA_004115215.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/ornithorhynchus_anatinus/GCA_004115215.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Ornithorhynchus_anatinus/GCA_004115215.2
   ensembl_link: https://www.ensembl.org/Ornithorhynchus_anatinus/Info/Index
 
 - species: Parambassis ranga
   image: Fish.png
   accession: GCA_900634625.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/genome/Parambassis_ranga-GCA_900634625.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parambassis_ranga/GCA_900634625.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/geneset/2019_05/Parambassis_ranga-GCA_900634625.1-2019_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1/genome/Parambassis_ranga-GCA_900634625.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parambassis_ranga/GCA_900634625.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.1
   ensembl_link: https://www.ensembl.org/Parambassis_ranga/Info/Index
 
 - species: Parambassis ranga
   image: Fish.png
   accession: GCA_900634625.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/genome/Parambassis_ranga-GCA_900634625.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parambassis_ranga/GCA_900634625.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/geneset/2020_09/Parambassis_ranga-GCA_900634625.2-2020_09-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2/genome/Parambassis_ranga-GCA_900634625.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/parambassis_ranga/GCA_900634625.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Parambassis_ranga/GCA_900634625.2
   rapid_link: https://rapid.ensembl.org/Parambassis_ranga_gca900634625v2/Info/Index
 
 - species: Periophthalmus magnuspinnatus
   image: Fish.png
   accession: GCA_009829125.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/genome/Periophthalmus_magnuspinnatus-GCA_009829125.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/periophthalmus_magnuspinnatus/GCA_009829125.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/geneset/2020_05/Periophthalmus_magnuspinnatus-GCA_009829125.1-2020_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1/genome/Periophthalmus_magnuspinnatus-GCA_009829125.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/periophthalmus_magnuspinnatus/GCA_009829125.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Periophthalmus_magnuspinnatus/GCA_009829125.1
   rapid_link: https://rapid.ensembl.org/Periophthalmus_magnuspinnatus/Info/Index
 
 - species: Phocoena sinus
   image: Mammals.png
   accession: GCA_008692025.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/genome/Phocoena_sinus-GCA_008692025.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phocoena_sinus/GCA_008692025.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/geneset/2020_03/Phocoena_sinus-GCA_008692025.1-2020_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1/genome/Phocoena_sinus-GCA_008692025.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phocoena_sinus/GCA_008692025.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Phocoena_sinus/GCA_008692025.1
   ensembl_link: https://www.ensembl.org/Phocoena_sinus/Info/Index
 
 - species: Phyllostomus discolor
   image: Mammals.png
   accession: GCA_004126475.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/genome/Phyllostomus_discolor-GCA_004126475.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phyllostomus_discolor/GCA_004126475.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/geneset/2020_04/Phyllostomus_discolor-GCA_004126475.2-2020_04-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2/genome/Phyllostomus_discolor-GCA_004126475.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phyllostomus_discolor/GCA_004126475.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.2
   rapid_link: https://rapid.ensembl.org/Phyllostomus_discolor/Info/Index
 
 - species: Phyllostomus discolor
   image: Mammals.png
   accession: GCA_004126475.3
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/genome/Phyllostomus_discolor-GCA_004126475.3-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phyllostomus_discolor/GCA_004126475.3.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/geneset/2020_07/Phyllostomus_discolor-GCA_004126475.3-2020_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3/genome/Phyllostomus_discolor-GCA_004126475.3-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/phyllostomus_discolor/GCA_004126475.3.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Phyllostomus_discolor/GCA_004126475.3
   rapid_link: https://rapid.ensembl.org/Phyllostomus_discolor_gca004126475v3/Info/Index
 
 - species: Pseudochaenichthys georgianus
   image: Fish.png
   accession: GCA_902827115.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/genome/Pseudochaenichthys_georgianus-GCA_902827115.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pseudochaenichthys_georgianus/GCA_902827115.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/geneset/2020_05/Pseudochaenichthys_georgianus-GCA_902827115.1-2020_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1/genome/Pseudochaenichthys_georgianus-GCA_902827115.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pseudochaenichthys_georgianus/GCA_902827115.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pseudochaenichthys_georgianus/GCA_902827115.1
   rapid_link: https://rapid.ensembl.org/Pseudochaenichthys_georgianus/Info/Index
 
 - species: Pygocentrus nattereri
   image: Fish.png
   accession: GCA_015220715.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/genome/Pygocentrus_nattereri-GCA_015220715.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pygocentrus_nattereri/GCA_015220715.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/geneset/2021_03/Pygocentrus_nattereri-GCA_015220715.1-2021_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1/genome/Pygocentrus_nattereri-GCA_015220715.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/pygocentrus_nattereri/GCA_015220715.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Pygocentrus_nattereri/GCA_015220715.1
   rapid_link: https://rapid.ensembl.org/Pygocentrus_nattereri_gca015220715v1/Info/Index
 
 - species: Rattus norvegicus (BN/NHsdMcwi)
   image: Mammals.png
   accession: GCA_015227675.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/genome/Rattus_norvegicus-GCA_015227675.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rattus_norvegicus/GCA_015227675.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/geneset/2021_02/Rattus_norvegicus-GCA_015227675.2-2021_02-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2/genome/Rattus_norvegicus-GCA_015227675.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/rattus_norvegicus/GCA_015227675.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Rattus_norvegicus/GCA_015227675.2
   ensembl_link: https://www.ensembl.org/Rattus_norvegicus/Info/Index
 
 - species: Salarias fasciatus
   image: Fish.png
   accession: GCA_902148845.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/genome/Salarias_fasciatus-GCA_902148845.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salarias_fasciatus/GCA_902148845.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/geneset/2019_08/Salarias_fasciatus-GCA_902148845.1-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1/genome/Salarias_fasciatus-GCA_902148845.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salarias_fasciatus/GCA_902148845.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Salarias_fasciatus/GCA_902148845.1
   ensembl_link: https://www.ensembl.org/Salarias_fasciatus/Info/Index
 
 - species: Salmo trutta
   image: Fish.png
   accession: GCA_901001165.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/genome/Salmo_trutta-GCA_901001165.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_trutta/GCA_901001165.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/geneset/2019_12/Salmo_trutta-GCA_901001165.1-2019_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1/genome/Salmo_trutta-GCA_901001165.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/salmo_trutta/GCA_901001165.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Salmo_trutta/GCA_901001165.1
   ensembl_link: https://www.ensembl.org/Salmo_trutta/Info/Index
 
 - species: Sarcophilus harrisii
   image: Mammals.png
   accession: GCA_902635505.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/genome/Sarcophilus_harrisii-GCA_902635505.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophilus_harrisii/GCA_902635505.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/geneset/2020_06/Sarcophilus_harrisii-GCA_902635505.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1/genome/Sarcophilus_harrisii-GCA_902635505.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sarcophilus_harrisii/GCA_902635505.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sarcophilus_harrisii/GCA_902635505.1
   ensembl_link: https://www.ensembl.org/Sarcophilus_harrisii/Info/Index
 
 - species: Sciurus vulgaris
   image: Mammals.png
   accession: GCA_902686455.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/genome/Sciurus_vulgaris-GCA_902686455.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_vulgaris/GCA_902686455.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/geneset/2020_01/Sciurus_vulgaris-GCA_902686455.1-2020_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1/genome/Sciurus_vulgaris-GCA_902686455.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sciurus_vulgaris/GCA_902686455.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sciurus_vulgaris/GCA_902686455.1
   ensembl_link: https://www.ensembl.org/Sciurus_vulgaris/Info/Index
 
 - species: Scleropages formosus
   image: Fish.png
   accession: GCA_900964775.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/genome/Scleropages_formosus-GCA_900964775.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scleropages_formosus/GCA_900964775.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/geneset/2019_06/Scleropages_formosus-GCA_900964775.1-2019_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1/genome/Scleropages_formosus-GCA_900964775.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/scleropages_formosus/GCA_900964775.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Scleropages_formosus/GCA_900964775.1
   ensembl_link: https://www.ensembl.org/Scleropages_formosus/Info/Index
 
 - species: Sebastes umbrosus
   image: Fish.png
   accession: GCA_015220745.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/genome/Sebastes_umbrosus-GCA_015220745.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sebastes_umbrosus/GCA_015220745.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/geneset/2022_01/Sebastes_umbrosus-GCA_015220745.1-2022_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1/genome/Sebastes_umbrosus-GCA_015220745.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sebastes_umbrosus/GCA_015220745.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sebastes_umbrosus/GCA_015220745.1
   rapid_link: https://rapid.ensembl.org/Sebastes_umbrosus_gca015220745v1/Info/Index
 
 - species: Sparus aurata
   image: Fish.png
   accession: GCA_900880675.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/genome/Sparus_aurata-GCA_900880675.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sparus_aurata/GCA_900880675.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/geneset/2019_09/Sparus_aurata-GCA_900880675.1-2019_09-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1/genome/Sparus_aurata-GCA_900880675.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sparus_aurata/GCA_900880675.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sparus_aurata/GCA_900880675.1
   ensembl_link: https://www.ensembl.org/Sparus_aurata/Info/Index
 
 - species: Sphaeramia orbicularis
   image: Fish.png
   accession: GCA_902148855.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/genome/Sphaeramia_orbicularis-GCA_902148855.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sphaeramia_orbicularis/GCA_902148855.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/geneset/2019_08/Sphaeramia_orbicularis-GCA_902148855.1-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1/genome/Sphaeramia_orbicularis-GCA_902148855.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/sphaeramia_orbicularis/GCA_902148855.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Sphaeramia_orbicularis/GCA_902148855.1
   ensembl_link: https://www.ensembl.org/Sphaeramia_orbicularis/Info/Index
 
 - species: Strigops habroptila
   image: Birds.png
   accession: GCA_004027225.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/genome/Strigops_habroptila-GCA_004027225.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/strigops_habroptila/GCA_004027225.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/geneset/2019_08/Strigops_habroptila-GCA_004027225.1-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1/genome/Strigops_habroptila-GCA_004027225.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/strigops_habroptila/GCA_004027225.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Strigops_habroptila/GCA_004027225.1
   ensembl_link: https://www.ensembl.org/Strigops_habroptila/Info/Index
 
 - species: Syngnathus acus
   image: Fish.png
   accession: GCA_901709675.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/genome/Syngnathus_acus-GCA_901709675.2-softmasked.fa.gz
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/geneset/2022_03/Syngnathus_acus-GCA_901709675.2-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2/genome/Syngnathus_acus-GCA_901709675.2-softmasked.fa.gz
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Syngnathus_acus/GCA_901709675.2
   rapid_link: https://rapid.ensembl.org/Syngnathus_acus_gca901709675v2/Info/Index
 
 - species: Taeniopygia guttata
   image: Birds.png
   accession: GCA_008822105.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/genome/Taeniopygia_guttata-GCA_008822105.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/taeniopygia_guttata/GCA_008822105.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/geneset/2019_10/Taeniopygia_guttata-GCA_008822105.1-2019_10-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1/genome/Taeniopygia_guttata-GCA_008822105.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/taeniopygia_guttata/GCA_008822105.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_008822105.1
   rapid_link: https://rapid.ensembl.org/Taeniopygia_guttata/Info/Index
 
 - species: Taeniopygia guttata
   image: Birds.png
   accession: GCA_003957565.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/genome/Taeniopygia_guttata-GCA_003957565.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/taeniopygia_guttata/GCA_003957565.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/geneset/2019_12/Taeniopygia_guttata-GCA_003957565.2-2019_12-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2/genome/Taeniopygia_guttata-GCA_003957565.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/taeniopygia_guttata/GCA_003957565.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Taeniopygia_guttata/GCA_003957565.2
   ensembl_link: https://www.ensembl.org/Taeniopygia_guttata/Info/Index
 
 - species: Takifugu rubripes
   image: Fish.png
   accession: GCA_901000725.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/genome/Takifugu_rubripes-GCA_901000725.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/takifugu_rubripes/GCA_901000725.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/geneset/2019_08/Takifugu_rubripes-GCA_901000725.2-2019_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2/genome/Takifugu_rubripes-GCA_901000725.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/takifugu_rubripes/GCA_901000725.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Takifugu_rubripes/GCA_901000725.2
   ensembl_link: https://www.ensembl.org/Takifugu_rubripes/Info/Index
 
 - species: Thalassophryne amazonica
   image: Fish.png
   accession: GCA_902500255.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/genome/Thalassophryne_amazonica-GCA_902500255.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thalassophryne_amazonica/GCA_902500255.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/geneset/2020_05/Thalassophryne_amazonica-GCA_902500255.1-2020_05-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1/genome/Thalassophryne_amazonica-GCA_902500255.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thalassophryne_amazonica/GCA_902500255.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Thalassophryne_amazonica/GCA_902500255.1
   rapid_link: https://rapid.ensembl.org/Thalassophryne_amazonica/Info/Index
 
 - species: Thamnophis elegans
   image: Reptiles.png
   accession: GCA_009769535.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/genome/Thamnophis_elegans-GCA_009769535.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thamnophis_elegans/GCA_009769535.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/geneset/2020_04/Thamnophis_elegans-GCA_009769535.1-2020_04-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1/genome/Thamnophis_elegans-GCA_009769535.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/thamnophis_elegans/GCA_009769535.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Thamnophis_elegans/GCA_009769535.1
   rapid_link: https://rapid.ensembl.org/Thamnophis_elegans/Info/Index
 
 - species: Toxotes jaculatrix
   image: Fish.png
   accession: GCA_017976425.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/genome/Toxotes_jaculatrix-GCA_017976425.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/toxotes_jaculatrix/GCA_017976425.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/geneset/2022_03/Toxotes_jaculatrix-GCA_017976425.1-2022_03-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1/genome/Toxotes_jaculatrix-GCA_017976425.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/toxotes_jaculatrix/GCA_017976425.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Toxotes_jaculatrix/GCA_017976425.1
   rapid_link: https://rapid.ensembl.org/Toxotes_jaculatrix_gca017976425v1/Info/Index
 
 - species: Trematomus bernacchii
   image: Fish.png
   accession: GCA_902827165.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/genome/Trematomus_bernacchii-GCA_902827165.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/trematomus_bernacchii/GCA_902827165.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/geneset/2020_07/Trematomus_bernacchii-GCA_902827165.1-2020_07-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1/genome/Trematomus_bernacchii-GCA_902827165.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/trematomus_bernacchii/GCA_902827165.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Trematomus_bernacchii/GCA_902827165.1
   rapid_link: https://rapid.ensembl.org/Trematomus_bernacchii/Info/Index
 
 - species: Tursiops truncatus
   image: Mammals.png
   accession: GCA_011762595.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/genome/Tursiops_truncatus-GCA_011762595.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tursiops_truncatus/GCA_011762595.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/geneset/2020_06/Tursiops_truncatus-GCA_011762595.1-2020_06-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1/genome/Tursiops_truncatus-GCA_011762595.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/tursiops_truncatus/GCA_011762595.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Tursiops_truncatus/GCA_011762595.1
   rapid_link: https://rapid.ensembl.org/Tursiops_truncatus/Info/Index
 
 - species: Zalophus californianus
   image: Mammals.png
   accession: GCA_009762305.1
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/genome/Zalophus_californianus-GCA_009762305.1-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zalophus_californianus/GCA_009762305.1.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/geneset/2020_01/Zalophus_californianus-GCA_009762305.1-2020_01-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1/genome/Zalophus_californianus-GCA_009762305.1-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zalophus_californianus/GCA_009762305.1.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.1
   ensembl_link: https://www.ensembl.org/Zalophus_californianus/Info/Index
 
 - species: Zalophus californianus
   image: Mammals.png
   accession: GCA_009762305.2
-  annotation_gtf: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-genes.gff3.gz
-  annotation_gff3: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-genes.gtf.gz
-  proteins: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-pep.fa.gz
-  transcripts: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-cdna.fa.gz
-  softmasked_genome: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/genome/Zalophus_californianus-GCA_009762305.2-softmasked.fa.gz
-  repeat_library: http://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zalophus_californianus/GCA_009762305.2.repeatmodeler.fa
-  ftp_dumps: http://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2
+  annotation_gtf: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-genes.gff3.gz
+  annotation_gff3: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-genes.gtf.gz
+  proteins: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-pep.fa.gz
+  transcripts: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/geneset/2020_08/Zalophus_californianus-GCA_009762305.2-2020_08-cdna.fa.gz
+  softmasked_genome: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2/genome/Zalophus_californianus-GCA_009762305.2-softmasked.fa.gz
+  repeat_library: https://ftp.ebi.ac.uk/pub/databases/ensembl/repeats/unfiltered_repeatmodeler/species/zalophus_californianus/GCA_009762305.2.repeatmodeler.fa
+  ftp_dumps: https://ftp.ensembl.org/pub/rapid-release/species/Zalophus_californianus/GCA_009762305.2
   rapid_link: https://rapid.ensembl.org/Zalophus_californianus_gca009762305v2/Info/Index
 

--- a/scripts/projects_page/write_yaml.py
+++ b/scripts/projects_page/write_yaml.py
@@ -30,7 +30,7 @@ def check_for_file(species_name, prod_name, accession, file_type):
     try:
         ftp.cwd(path)
         if file_name in ftp.nlst():
-            return "http://ftp.ebi.ac.uk/" + path + file_name
+            return "https://ftp.ebi.ac.uk/" + path + file_name
         else:
             return 0
     except:
@@ -98,7 +98,7 @@ def write_yaml(info_dict, icon, yaml_out, project, use_server, alternate):
         submitter = "Genome Reference Consortium"
 
     if use_server == "rapid":
-        ftp_base = "http://ftp.ensembl.org/pub/rapid-release/species"
+        ftp_base = "https://ftp.ensembl.org/pub/rapid-release/species"
 
         yaml = "- species: " + info_dict["species.scientific_name"] + "\n"
 
@@ -252,7 +252,7 @@ def write_yaml(info_dict, icon, yaml_out, project, use_server, alternate):
         else:
             release = "release-" + info_dict["schema_version"]
             release_number = info_dict["schema_version"]
-        ftp_base = "http://ftp.ensembl.org/pub/" + release
+        ftp_base = "https://ftp.ensembl.org/pub/" + release
 
         yaml = "- species: " + info_dict["species.scientific_name"] + "\n"
         if project in ("vgp", "dtol"):


### PR DESCRIPTION
This PR updates all http://ftp URLs to https.
The affected URL hostnames have been tested working with https.
Similar PRs in other repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680/