### PR TITLE
fixed default setting for adding meta key

### DIFF
--- a/ensembl_genes/Repeatmask_Red.py
+++ b/ensembl_genes/Repeatmask_Red.py
@@ -39,7 +39,7 @@ class Repeatmask_Red(eHive.BaseRunnable):
             'logic_name' : 'repeatdetector',
             'target_db_url' : '', # 'driver://user:pass@host:port/dbname'
             'red_path' : '',
-            'red_meta_key' : 0
+            'red_meta_key' : 1
         }
 
     def fetch_input(self):


### PR DESCRIPTION
# Requirements
When creating your Pull request, please fill out the template below:

# PR details
_Is this a fix/ update/ new feature?_
fix
_Include a short description_
The default settings for Red include adding the meta key in the db, if the param is not defined or set to 0 as in the main pipeline the meta key is not added.
_Include links to JIRA tickets_

# Testing
_Have you tested it?_

# Assign to the weekly GitHub reviewer
_If you are a member of Ensembl, please check the Genebuild weekly Rotas and assign this week's GitHub reviewer to the PR_
@thibauthourlier 