### PR TITLE
All nightly test can fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
       env: TESTENV=doc
     allow_failures:
     - python: nightly
+      env: TESTENV=code
+    - python: nightly
       env: TESTENV=pylint
     - python: nightly
       env: TESTENV=black


### PR DESCRIPTION
This commit should stop Travis from failling when using python nightly