### PR TITLE
Fix to unknown 'line' var & convert to string

### DIFF
--- a/scripts/transcriptomic_data/get_transcriptomic_data.py
+++ b/scripts/transcriptomic_data/get_transcriptomic_data.py
@@ -145,7 +145,7 @@ def main() -> None:
 
         with open(Path(args.csv_file), "w", encoding="utf8") as csv_file:
             for row in csv_data:
-                csv_file.write(line + "\n")
+                csv_file.write("\t".join(row) + "\n")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The error given before change when running the script stated:
_NameError: name 'line' is not defined_

Which makes sense, given var line is not defined. Variable row is of type _tuple_  and not a string which also caused further python error. 

Additionally the file outname is stated as csv... but the "csv" file produced was always in fact a TSV. 