### PR TITLE
fixing issues with bad request missing json and missing md5 column

### DIFF
--- a/scripts/transcriptomic_data/get_transcriptomic_data.py
+++ b/scripts/transcriptomic_data/get_transcriptomic_data.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 """Download short and long read data from ENA website"""
 import os.path
+import sys
 from pathlib import Path
 from typing import List
 import argparse
 import requests
-
+import json
 
 def get_sample_info(accession: str) -> List:
     """Get info about sample name and description for the run accession"""
     biosample_url = f"https://www.ebi.ac.uk/biosamples/samples/{accession}"
-    biosample_data = requests.get(biosample_url).json()
+    biosample_data = None
+    try:
+      req_res = requests.get(biosample_url)
+      biosample_data = req_res.json()
+    except json.decoder.JSONDecodeError as ex:
+      print(f"Got exception for {accession}: {ex} when parsing {req_res}", file = sys.stderr)
+    if not biosample_data:
+      return ("failed", "failed")
 
     # sample name will be set as the tissue type or organism part fields from ENA BioSample
     # if neither exist, sample name is "unknown"
@@ -84,7 +92,7 @@ def get_data_from_ena(# pylint: disable=too-many-locals
     centre = "ENA"  # we get everything from ENA anyway
     
     for row in results:
-        row_data = row.split()
+        row_data = row.split() + [""] * 6
         run_accession = row_data[0]
         sample_accession = row_data[1]
         sample, description = get_sample_info(sample_accession)

--- a/scripts/transcriptomic_data/get_transcriptomic_data.py
+++ b/scripts/transcriptomic_data/get_transcriptomic_data.py
@@ -26,12 +26,12 @@ def get_sample_info(accession: str) -> List:
     biosample_url = f"https://www.ebi.ac.uk/biosamples/samples/{accession}"
     biosample_data = None
     try:
-      req_res = requests.get(biosample_url)
-      biosample_data = req_res.json()
+        req_res = requests.get(biosample_url)
+        biosample_data = req_res.json()
     except json.decoder.JSONDecodeError as ex:
-      print(f"Got exception for {accession}: {ex} when parsing {req_res}", file = sys.stderr)
+        print(f"Got exception for {accession}: {ex} when parsing {req_res}", file = sys.stderr)
     if not biosample_data:
-      return ("failed", "failed")
+        return ("failed", "failed")
 
     # sample name will be set as the tissue type or organism part fields from ENA BioSample
     # if neither exist, sample name is "unknown"


### PR DESCRIPTION
Adding warning instead of dying when bad responses from "https://www.ebi.ac.uk/biosamples/samples/{accession}"

```
python scripts/transcriptomic_data/get_transcriptomic_data.py -read_type short -t 79327 -f sm.csv
Got exception for SAMN37120897: Expecting value: line 1 column 1 (char 0) when parsing <Response [404]>
```