### PR TITLE
fixing issues with missing json for biosamples erroneous responses

### DIFF
--- a/scripts/transcriptomic_data/get_transcriptomic_data.py
+++ b/scripts/transcriptomic_data/get_transcriptomic_data.py
@@ -32,7 +32,7 @@ def get_sample_info(accession: str) -> List:
     except json.decoder.JSONDecodeError as ex:
         print(f"Got exception for {accession}: {ex} when parsing {req_res}", file = sys.stderr)
     if not biosample_data:
-        return ("failed", "failed")
+        return ("unknown", f"failed to get data for {accession}")
 
     # sample name will be set as the tissue type or organism part fields from ENA BioSample
     # if neither exist, sample name is "unknown"

--- a/scripts/transcriptomic_data/get_transcriptomic_data.py
+++ b/scripts/transcriptomic_data/get_transcriptomic_data.py
@@ -14,16 +14,26 @@
 # limitations under the License.
 """Download short and long read data from ENA website"""
 import os.path
+import sys
 from pathlib import Path
 from typing import List
 import argparse
 import requests
+import json
 
 
 def get_sample_info(accession: str) -> List:
     """Get info about sample name and description for the run accession"""
     biosample_url = f"https://www.ebi.ac.uk/biosamples/samples/{accession}"
-    biosample_data = requests.get(biosample_url).json()
+    biosample_data = None
+    try:
+        req_res = requests.get(biosample_url)
+        biosample_data = req_res.json()
+    except json.decoder.JSONDecodeError as ex:
+        print(f"Got exception for {accession}: {ex} when parsing {req_res}", file = sys.stderr)
+    if not biosample_data:
+        return ("failed", "failed")
+
     # sample name will be set as the tissue type or organism part fields from ENA BioSample
     # if neither exist, sample name is "unknown"
     # this requires a project for working out the best way to find sample names that make sense


### PR DESCRIPTION
Adding warning instead of dying when bad responses from "[https://www.ebi.ac.uk/biosamples/samples/{accession}](https://www.ebi.ac.uk/biosamples/samples/%7Baccession%7D)".
When it's not possible to parse the sample data for {accession}, status is changed to "unknown" and  description is changed to " failed to get data for {accession}" 

```
python scripts/transcriptomic_data/get_transcriptomic_data.py -read_type short -t 79327 -f sm.csv
Got exception for SAMN37120897: Expecting value: line 1 column 1 (char 0) when parsing <Response [404]>
...

```
```
grep SAMN37120917 short_set/sm.csv
unknown SRR25740123     1       SRR25740123_1.fastq.gz  -1      1       0       ENA     ILLUMINA        failed to get data for SAMN37120917     ftp.sra.ebi.ac.uk/vol1/fastq/SRR257/023/SRR25740123/SRR25740123_1.fastq.gz       e048f5a19920d18a91d3117c81b84547
unknown SRR25740123     1       SRR25740123_2.fastq.gz  -1      1       0       ENA     ILLUMINA        failed to get data for SAMN37120917     ftp.sra.ebi.ac.uk/vol1/fastq/SRR257/023/SRR25740123/SRR25740123_2.fastq.gz       c27aa5b787658c073ec3aa00aee80f11
```