### PR TITLE
New script for tracking Ensembl status of a BioProject

### DIFF
--- a/src/python/ensembl/genes/tracking/README.md
+++ b/src/python/ensembl/genes/tracking/README.md
@@ -1,0 +1,32 @@
+#
+
+## About
+
+
+## Running bioproject_tracking.py
+
+**python bioproject_tracking.py  -h**
+
+usage: bioproject_tracking.py [-h] [--haploid] [--report_file REPORT_FILE] [--rank RANK] bioproject_id
+
+Fetch assembly accessions from NCBI BioProject and report the number of corresponding annotations in rapid.ensembl.org.
+
+positional arguments:
+  bioproject_id         NCBI BioProject ID
+
+optional arguments:
+  -h, --help                     show this help message and exit
+      --haploid                  Fetch only haploid assemblies
+      --report_file REPORT_FILE  Where to write report to
+      --rank RANK                Taxonomic rank to classify
+
+## Example Usage
+
+I want to report the number of DToL assemblies for which I can find annotation on rapid.ensembl.org. I only want to report for primary haplotypes (use --haploid flag) and I want a breakdown by taxonomic class:
+
+**python bioproject_tracking.py --haploid PRJEB40665 --rank class --report_file ./dtol_rank_report_file.csv**
+Found 1637 assemblies under BioProject ID PRJEB40665
+Found 631 annotations in rapid.ensembl.org for 612 unique species
+
+Breakdown:
+Counter({'Insecta': 591, 'Mammalia': 10, 'Magnoliopsida': 6, 'Actinopteri': 5, 'Gastropoda': 4, 'Bivalvia': 4, 'Amphibia': 2, 'Anthozoa': 2, 'Clitellata': 2, 'Aves': 2, 'Asteroidea': 1, 'Staurozoa': 1, 'Pilidiophora': 1})

--- a/src/python/ensembl/genes/tracking/README.md
+++ b/src/python/ensembl/genes/tracking/README.md
@@ -5,6 +5,7 @@
 
 ## Running bioproject_tracking.py
 
+```
 **python bioproject_tracking.py  -h**
 
 usage: bioproject_tracking.py [-h] [--haploid] [--report_file REPORT_FILE] [--rank RANK] bioproject_id
@@ -12,29 +13,25 @@ usage: bioproject_tracking.py [-h] [--haploid] [--report_file REPORT_FILE] [--ra
 Fetch assembly accessions from NCBI BioProject and report the number of corresponding annotations in rapid.ensembl.org.
 
 positional arguments:
-
   bioproject_id         NCBI BioProject ID
 
 optional arguments:
-
-  -h, --help                     show this help message and exit
-
-      --haploid                  Fetch only haploid assemblies
-
-      --report_file REPORT_FILE  Where to write report to
-
-      --rank RANK                Taxonomic rank to classify
+  -h, --help                 show this help message and exit
+  --haploid                  Fetch only haploid assemblies
+  --report_file REPORT_FILE  Where to write report to
+  --rank RANK                Taxonomic rank to classify
+```
 
 ## Example Usage
 
 I want to report the number of DToL assemblies for which I can find annotation on rapid.ensembl.org. I only want to report for primary haplotypes (use --haploid flag) and I want a breakdown by taxonomic class:
 
+```
 **python bioproject_tracking.py --haploid PRJEB40665 --rank class --report_file ./dtol_rank_report_file.csv**
 
 Found 1637 assemblies under BioProject ID PRJEB40665
-
 Found 631 annotations in rapid.ensembl.org for 612 unique species
 
 Breakdown:
-
 Counter({'Insecta': 591, 'Mammalia': 10, 'Magnoliopsida': 6, 'Actinopteri': 5, 'Gastropoda': 4, 'Bivalvia': 4, 'Amphibia': 2, 'Anthozoa': 2, 'Clitellata': 2, 'Aves': 2, 'Asteroidea': 1, 'Staurozoa': 1, 'Pilidiophora': 1})
+```

--- a/src/python/ensembl/genes/tracking/README.md
+++ b/src/python/ensembl/genes/tracking/README.md
@@ -12,12 +12,17 @@ usage: bioproject_tracking.py [-h] [--haploid] [--report_file REPORT_FILE] [--ra
 Fetch assembly accessions from NCBI BioProject and report the number of corresponding annotations in rapid.ensembl.org.
 
 positional arguments:
+
   bioproject_id         NCBI BioProject ID
 
 optional arguments:
+
   -h, --help                     show this help message and exit
+
       --haploid                  Fetch only haploid assemblies
+
       --report_file REPORT_FILE  Where to write report to
+
       --rank RANK                Taxonomic rank to classify
 
 ## Example Usage
@@ -25,8 +30,11 @@ optional arguments:
 I want to report the number of DToL assemblies for which I can find annotation on rapid.ensembl.org. I only want to report for primary haplotypes (use --haploid flag) and I want a breakdown by taxonomic class:
 
 **python bioproject_tracking.py --haploid PRJEB40665 --rank class --report_file ./dtol_rank_report_file.csv**
+
 Found 1637 assemblies under BioProject ID PRJEB40665
+
 Found 631 annotations in rapid.ensembl.org for 612 unique species
 
 Breakdown:
+
 Counter({'Insecta': 591, 'Mammalia': 10, 'Magnoliopsida': 6, 'Actinopteri': 5, 'Gastropoda': 4, 'Bivalvia': 4, 'Amphibia': 2, 'Anthozoa': 2, 'Clitellata': 2, 'Aves': 2, 'Asteroidea': 1, 'Staurozoa': 1, 'Pilidiophora': 1})

--- a/src/python/ensembl/genes/tracking/bioproject_tracking.py
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import argparse
 import requests
 import pymysql
@@ -62,7 +63,12 @@ def mysql_fetch_data(query: str, database: str, host: str, port: int, user: str)
 
     cursor.close()
     conn.close()
-    return info
+    try: 
+        return info
+    except UnboundLocalError:
+        print(f"\nNothing returned for SQL query: {query}\n")
+        sys.exit()
+    
 
 def get_assembly_accessions(bioproject_id: str, only_haploid: bool = False) -> List[str]:
     """
@@ -152,10 +158,10 @@ def get_ensembl_live(bioproject_accessions_taxon: Dict[str, Dict[str, int]]) -> 
     )
     data_fetch = mysql_fetch_data(
         data_query,
-        'ensembl_metadata_qrp',
-        config["server_details"]["meta"]["db_host"],
-        config["server_details"]["meta"]["db_port"],
-        config["server_details"]["meta"]["db_user"],
+        config["server_details"]["meta"]["rapid"]["db_name"],
+        config["server_details"]["meta"]["rapid"]["db_host"],
+        config["server_details"]["meta"]["rapid"]["db_port"],
+        config["server_details"]["meta"]["rapid"]["db_user"],
     )
     live_annotations = {}
     for tuple in data_fetch:

--- a/src/python/ensembl/genes/tracking/bioproject_tracking.py
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking.py
@@ -225,11 +225,11 @@ def main():
     """
     Main function to handle command-line arguments and output the result.
     """
-    parser = argparse.ArgumentParser(description='Fetch assembly accessions from NCBI BioProject.')
+    parser = argparse.ArgumentParser(description='Fetch assembly accessions from NCBI BioProject and report the number of corresponding annotations in rapid.ensembl.org.')
     parser.add_argument('bioproject_id', type=str, help='NCBI BioProject ID')
     parser.add_argument('--haploid', action='store_true', help='Fetch only haploid assemblies')
     parser.add_argument('--report_file', type=str, help='Where to write report to', default='./report_file.csv')
-    parser.add_argument('--rank', type=str, help='Taoxnomic rank to classify', default='order')
+    parser.add_argument('--rank', type=str, help='Taxonomic rank to classify', default='order')
     
     args = parser.parse_args()
 
@@ -237,8 +237,8 @@ def main():
     live_annotations = get_ensembl_live(bioproject_accessions_taxon)
     live_annotations_classified = get_taxonomy_info(live_annotations, bioproject_accessions_taxon, args.rank)
     unique_taxon_ids = {details['taxon_id'] for details in live_annotations.values()}
-    print("Found " +  str(len(bioproject_accessions_taxon)) + " assemblies under BioProject ID " + args.bioproject_id)
-    print("Found " + str(len(live_annotations)) + " annotations in rapid.ensembl.org for " + str(len(unique_taxon_ids)) + " unique species")
+    print(f"Found {len(bioproject_accessions_taxon)} assemblies under BioProject ID {args.bioproject_id}")
+    print(f"Found {len(live_annotations)} annotations in rapid.ensembl.org for {len(unique_taxon_ids)} unique species")
 
     rank_values = [details[args.rank] for details in live_annotations.values()]
     rank_counts = Counter(rank_values)

--- a/src/python/ensembl/genes/tracking/bioproject_tracking.py
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking.py
@@ -1,0 +1,250 @@
+# See the NOTICE file distributed with this work for additional information #pylint: disable=missing-module-docstring
+# regarding copyright ownership.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import requests
+import pymysql
+import json
+from pathlib import Path
+from collections import Counter
+
+with open("./bioproject_tracking_config.json", "r") as f:
+    config = json.load(f)
+
+def mysql_fetch_data(query, database, host, port, user):
+    """
+    Executes a given SQL query on a MySQL database and fetches the result.
+
+    This function establishes a connection to the MySQL database using provided connection details.
+    It then executes the given query using a cursor obtained from the connection. After executing the query,
+    it fetches all the rows of the query result and returns them. The function handles any errors that might
+    occur during the process and ensures that the database connection is closed before returning the result.
+
+    Args:
+        query (str): The SQL query to be executed.
+        database (str): The name of the database to connect to.
+        host (str): The host name or IP address of the MySQL server.
+        port (int): The port number to use for the connection.
+        user (str): The username to use for the database connection.
+
+    Returns:
+        tuple: A tuple of tuples containing the rows returned by the query execution.
+
+    Note:
+        This function does not handle database password authentication. Ensure that the provided user
+        has the necessary permissions and that the database is configured to allow password-less connections
+        from the given host.
+    """
+    try:
+        conn = pymysql.connect(
+            host=host, user=user, port=port, database=database.strip()
+        )
+
+        cursor = conn.cursor()
+        cursor.execute(query)
+        info = cursor.fetchall()
+
+    except pymysql.Error as err:
+        print(err)
+
+    cursor.close()
+    conn.close()
+    return info
+    
+def get_assembly_accessions(bioproject_id, only_haploid=False):
+    """
+    Fetches assembly accessions from a given NCBI BioProject ID.
+
+    Args:
+    bioproject_id (str): The NCBI BioProject ID.
+    only_haploid (bool): If True, fetch only haploid assemblies. Defaults to False.
+
+    Returns:
+    list: A list of assembly accessions.
+    """
+    base_url = "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/bioproject"
+    next_page_token = None
+    assembly_accessions = {}
+
+    while True:
+        url = f"{base_url}/{bioproject_id}/dataset_report"
+        if next_page_token:
+            url += f"?page_token={next_page_token}"
+
+        response = requests.get(url)
+        response.raise_for_status()
+        data = response.json()
+
+        assemblies = data.get('reports', [])
+        for assembly in assemblies:
+            assembly_info = assembly.get('assembly_info', {})
+            if only_haploid and assembly_info.get('assembly_type') != 'haploid':
+                continue
+            assembly_accession = assembly.get('accession')
+            taxon_id = assembly.get('organism').get('tax_id')
+            if assembly_accession:
+                assembly_accessions[assembly_accession] = {"taxon_id" : taxon_id}
+
+        # Check for the next page token or equivalent
+        next_page_token = data.get('next_page_token')
+        if not next_page_token:
+            break
+
+    return assembly_accessions
+
+def get_ensembl_live(bioproject_accessions_taxon):
+    """
+    Retrieves live Ensembl database names for a set of bioproject accessions.
+
+    This function constructs and executes a SQL query to fetch the latest Ensembl database names (denoted as 'dbname')
+    associated with a list of assembly accessions. The query selects databases where the assembly accession matches
+    those provided and filters for 'core' databases in the latest data release. The information is then used to
+    update and return a dictionary mapping each accession to its corresponding taxonomy information and live Ensembl 
+    'dbname'.
+
+    Args:
+        bioproject_accessions_taxon (dict): A dictionary where keys are assembly accessions and values are dictionaries 
+                                            containing taxonomy information for those accessions.
+
+    Returns:
+        dict: A dictionary where each key is an assembly accession, and each value is a dictionary with the original 
+              taxonomy information plus a 'dbname' key containing the name of the live Ensembl database for that accession.
+
+    Requires:
+        - A working connection to the Ensembl metadata database specified by the configuration in `config`.
+        - The `mysql_fetch_data` function to execute the query and fetch data.
+
+    Example:
+        >>> bioproject_accessions_taxon = {'GCA_123456.1': {'taxon_id': 9606}}
+        >>> live_annotations = get_ensembl_live(bioproject_accessions_taxon)
+        >>> print(live_annotations)
+        {'GCA_123456.1': {'taxon_id': 9606, 'dbname': 'homo_sapiens_core_104_38'}}
+
+    Note:
+        The configuration for the database connection (`config`) must be defined externally with keys for 
+        'db_host', 'db_port', and 'db_user' within a nested 'server_details'->'meta' structure.
+    """
+    accessions = list(bioproject_accessions_taxon.keys())
+    formatted_accessions = ",".join(f'"{item}"' for item in accessions)
+    data_query = (
+        "SELECT assembly.assembly_accession, dbname FROM assembly JOIN genome USING (assembly_id) JOIN genome_database USING (genome_id) WHERE genome.data_release_id=(SELECT MAX(data_release_id) FROM genome) AND assembly.assembly_accession in (" + formatted_accessions + ") AND dbname like '%core%';"
+    )
+    data_fetch = mysql_fetch_data(
+        data_query,
+        'ensembl_metadata_qrp',
+        config["server_details"]["meta"]["db_host"],
+        config["server_details"]["meta"]["db_port"],
+        config["server_details"]["meta"]["db_user"],
+    )
+    live_annotations = {}
+    for tuple in data_fetch:
+        accession = tuple[0]
+        live_info = {"dbname" : tuple[1]}
+        live_annotations[accession] = bioproject_accessions_taxon[accession]
+        live_annotations[accession].update(live_info)
+    return(live_annotations)
+    
+def get_taxonomy_info(live_annotations, bioproject_accessions_taxon, rank):
+    """
+    Updates the live_annotations dictionary with taxonomy information for a specified rank.
+    
+    This function iterates over each accession in live_annotations, retrieves the corresponding taxon ID,
+    and makes a request to the NCBI Datasets API to fetch taxonomy information. It then updates the 
+    live_annotations dictionary with the name of the specified rank (e.g., 'order', 'family') for each accession.
+    
+    Args:
+        live_annotations (dict): A dictionary where each key is an accession number and its value is another 
+                                  dictionary with various annotation details. This dictionary is updated in-place.
+        bioproject_accessions_taxon (dict): A dictionary mapping accession numbers to their respective taxon 
+                                            information, including taxon IDs.
+        rank (str): The taxonomic rank for which the name should be retrieved and added to live_annotations 
+                    (e.g., 'order', 'family').
+
+    Returns:
+        dict: The updated live_annotations dictionary with the added taxonomy information for the specified rank.
+
+    Raises:
+        requests.HTTPError: If an HTTP error occurs during the API request.
+        Exception: If any other error occurs during the function's operation.
+
+    Note:
+        The function updates live_annotations in-place and also returns it for convenience. Each accession in 
+        live_annotations is updated with a new key-value pair, where the key is the specified rank and the value 
+        is the name of that rank from the taxonomy data.
+
+    Example:
+        >>> live_annotations = {'accession1': {'some_annotation': 'value'}}
+        >>> bioproject_accessions_taxon = {'accession1': {'taxon_id': '12345'}}
+        >>> rank = 'order'
+        >>> updated_annotations = get_taxonomy_info(live_annotations, bioproject_accessions_taxon, rank)
+        >>> print(updated_annotations)
+        {'accession1': {'some_annotation': 'value', 'order': 'SomeOrderName'}}
+    """
+    for accession in live_annotations:
+        taxon_id = bioproject_accessions_taxon[accession]["taxon_id"]
+        url = f"https://api.ncbi.nlm.nih.gov/datasets/v2alpha/taxonomy/taxon/{taxon_id}/dataset_report"
+        
+        try:
+            response = requests.get(url)
+            response.raise_for_status()  # Raises an HTTPError if the response status code is 4XX or 5XX
+            data = response.json()
+            taxonomies = data.get('reports', [])
+            for taxonomy in taxonomies:
+                rank_name = taxonomy.get('taxonomy', {}).get('classification', {}).get(rank, {}).get('name')
+                taxonomy_info = {rank : rank_name}
+                live_annotations[accession].update(taxonomy_info)
+                
+        except requests.HTTPError as http_err:
+            print(f"HTTP error occurred: {http_err}")
+        except Exception as err:
+            print(f"An error occurred: {err}")
+           
+    return(live_annotations)
+        
+def write_report(live_annotations, report_file, rank):
+    with open(Path(report_file), "w", encoding="utf8") as report_file:
+        for accession in live_annotations:
+            try:
+                report_file.write(accession + '\t' + live_annotations[accession]["dbname"] + '\t' + live_annotations[accession][rank] + '\n')
+            except TypeError:
+                report_file.write(accession + '\t' + live_annotations[accession]["dbname"] + '\t unknown \n')
+                print(live_annotations[accession])
+def main():
+    """
+    Main function to handle command-line arguments and output the result.
+    """
+    parser = argparse.ArgumentParser(description='Fetch assembly accessions from NCBI BioProject.')
+    parser.add_argument('bioproject_id', type=str, help='NCBI BioProject ID')
+    parser.add_argument('--haploid', action='store_true', help='Fetch only haploid assemblies')
+    parser.add_argument('--report_file', type=str, help='Where to write report to', default='./report_file.csv')
+    parser.add_argument('--rank', type=str, help='Taoxnomic rank to classify', default='order')
+    
+    args = parser.parse_args()
+
+    bioproject_accessions_taxon = get_assembly_accessions(args.bioproject_id, args.haploid)
+    live_annotations = get_ensembl_live(bioproject_accessions_taxon)
+    live_annotations_classified = get_taxonomy_info(live_annotations, bioproject_accessions_taxon, args.rank)
+    unique_taxon_ids = {details['taxon_id'] for details in live_annotations.values()}
+    print("Found " +  str(len(bioproject_accessions_taxon)) + " assemblies under BioProject ID " + args.bioproject_id)
+    print("Found " + str(len(live_annotations)) + " annotations in rapid.ensembl.org for " + str(len(unique_taxon_ids)) + " unique species")
+
+    rank_values = [details[args.rank] for details in live_annotations.values()]
+    rank_counts = Counter(rank_values)
+    print("\nBreakdown:")
+    print(rank_counts)
+    write_report(live_annotations, args.report_file, args.rank)
+    
+if __name__ == "__main__":
+    main()

--- a/src/python/ensembl/genes/tracking/bioproject_tracking.py
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking.py
@@ -19,11 +19,12 @@ import pymysql
 import json
 from pathlib import Path
 from collections import Counter
+from typing import List, Tuple, Any, Dict
 
 with open("./bioproject_tracking_config.json", "r") as f:
     config = json.load(f)
 
-def mysql_fetch_data(query, database, host, port, user):
+def mysql_fetch_data(query: str, database: str, host: str, port: int, user: str) -> List[Tuple[Any, ...]]:
     """
     Executes a given SQL query on a MySQL database and fetches the result.
 
@@ -62,8 +63,8 @@ def mysql_fetch_data(query, database, host, port, user):
     cursor.close()
     conn.close()
     return info
-    
-def get_assembly_accessions(bioproject_id, only_haploid=False):
+
+def get_assembly_accessions(bioproject_id: str, only_haploid: bool = False) -> List[str]:
     """
     Fetches assembly accessions from a given NCBI BioProject ID.
 
@@ -104,7 +105,7 @@ def get_assembly_accessions(bioproject_id, only_haploid=False):
 
     return assembly_accessions
 
-def get_ensembl_live(bioproject_accessions_taxon):
+def get_ensembl_live(bioproject_accessions_taxon: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, str]]:
     """
     Retrieves live Ensembl database names for a set of bioproject accessions.
 
@@ -155,8 +156,12 @@ def get_ensembl_live(bioproject_accessions_taxon):
         live_annotations[accession] = bioproject_accessions_taxon[accession]
         live_annotations[accession].update(live_info)
     return(live_annotations)
-    
-def get_taxonomy_info(live_annotations, bioproject_accessions_taxon, rank):
+
+def get_taxonomy_info(
+            live_annotations: Dict[str, Dict[str, str]],
+            bioproject_accessions_taxon: Dict[str, Dict[str, int]],
+            rank: str
+        ) -> Dict[str, Dict[str, str]]:
     """
     Updates the live_annotations dictionary with taxonomy information for a specified rank.
     

--- a/src/python/ensembl/genes/tracking/bioproject_tracking.py
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking.py
@@ -75,7 +75,7 @@ def get_assembly_accessions(bioproject_id: str, only_haploid: bool = False) -> L
     Returns:
     list: A list of assembly accessions.
     """
-    base_url = "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/bioproject"
+    base_url = config["urls"]["datasets"]["bioproject"]
     next_page_token = None
     assembly_accessions = {}
     

--- a/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
@@ -1,0 +1,9 @@
+{
+    "server_details" : {
+	"meta": {
+	    "db_host" : "mysql-ens-meta-prod-1",
+	    "db_user" : "ensro",
+	    "db_port" : 4483
+	}
+    }
+}

--- a/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
@@ -5,5 +5,10 @@
 	    "db_user" : "ensro",
 	    "db_port" : 4483
 	}
+    },
+    "urls" : {
+	"datasets" : {
+	    "bioproject" : "https://api.ncbi.nlm.nih.gov/datasets/v2alpha/genome/bioproject"
+	}
     }
 }

--- a/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
@@ -1,9 +1,12 @@
 {
     "server_details" : {
 	"meta": {
-	    "db_host" : "mysql-ens-meta-prod-1",
-	    "db_user" : "ensro",
-	    "db_port" : 4483
+	    "rapid" : {
+		"db_name" : "ensembl_metadata_qrp",
+		"db_host" : "mysql-ens-meta-prod-1",
+		"db_user" : "ensro",
+		"db_port" : 4483
+	    }
 	}
     },
     "urls" : {

--- a/src/python/ensembl/genes/tracking/requirements.txt
+++ b/src/python/ensembl/genes/tracking/requirements.txt
@@ -1,0 +1,2 @@
+requests=2.27.1
+PyMySQL=1.0.2


### PR DESCRIPTION
Provide the script with the BioProject ID and taxonomic rank for the breakdown (default is 'order') and it will report the number of annotations in rapid (and how many unique species are covered), plus a breakdown by taxonomic rank.

use the --haploid flag to only report for primary haplotypes

Things still to do:
- Allow for use to select for only alternates (assembly_type="alternate-pseudohaplotype")
- Add functionality for groupings outside of BioProjects, e.g farmed (will be much simpler when assembly registry us ready)
- Speed-up (may also be possible with assembly registry completed (?))
- Improved reporting (diagrams, charts, etc.?)