### PR TITLE
added plants icon to icons.txt

### DIFF
--- a/scripts/projects_page/icons.txt
+++ b/scripts/projects_page/icons.txt
@@ -11,3 +11,4 @@ Coleoptera	Arthropods.png
 Hemiptera	Arthropods.png
 Trichoptera	Arthropods.png
 Neoptera	Arthropods.png
+Viridiplantae	Plants.png


### PR DESCRIPTION
The [Plants.png icon](https://github.com/Ensembl/projects.ensembl.org/blob/main/img/vgp/Plants.png) had not been added to the icons.txt file and so the plant genomes on the Project Pages had the generic metazoa icon.

See the [GitHub README](https://github.com/Ensembl/ensembl-genes/blob/main/scripts/projects_page/README.md) for instructions for adding new icons.
