### PR TITLE
Adding FTP to the report

### DIFF
--- a/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
+++ b/src/python/ensembl/genes/tracking/bioproject_tracking_config.json
@@ -7,7 +7,16 @@
 		"db_user" : "ensro",
 		"db_port" : 4483
 	    }
+	},
+	"data": {
+	    "rapid" : {
+                "db_name" : "",
+                "db_host" : "mysql-ens-sta-5",
+                "db_user" : "ensro",
+                "db_port" : 4684
+	    }
 	}
+	
     },
     "urls" : {
 	"datasets" : {


### PR DESCRIPTION
I've added functionality for constructing the beta ftp links for the geneset data per genome in the report. 
Notes:
- Although the ftp links are for beta, for now, the script still works on the rapid staging server - I will update this in december
- For now the links are to the geneset directories, but I will consider adding different file links (specified by flag) in a future iteration