### PR TITLE
species.common_name fix for microbes

### DIFF
--- a/src/python/ensembl/genes/metadata/core_meta_data.py
+++ b/src/python/ensembl/genes/metadata/core_meta_data.py
@@ -546,6 +546,8 @@ if __name__ == "__main__":
                 logger.critical(f"You are missing required meta key: {required_key}")
 
     # report if there has been a change in common name
+    if "species.common_name" not in core_dict:
+        core_dict["species.common_name"] = ''
     if core_dict["species.common_name"].lower() != truth_dict["organism.common_name"].lower():
         logger.warning(
             ' | COMMON NAME | The value for species.common_name in your meta table: "'


### PR DESCRIPTION
For some microbes core dbs the species.common_name meta key will be missing, but is required by the script, so just setting it to empty string