### PR TITLE
added functionality for collections + checks for some required keys

### DIFF
--- a/src/python/ensembl/genes/metadata/core_meta_data.py
+++ b/src/python/ensembl/genes/metadata/core_meta_data.py
@@ -231,17 +231,6 @@ if __name__ == "__main__":
     )
     logger = logging.getLogger()
     logger.propagate = False
-    # Dealing with collection dbs - this should be done better!!!
-    #if db == "bacteria_0_collection_core_57_110_1":
-    #    species_id = "99"
-    #elif db == "fungi_ascomycota2_collection_core_57_110_1":
-    #    species_id = "19"
-    #elif db == "protists_choanoflagellida1_collection_core_57_110_1":
-    #    species_id = "2"
-    #elif db == "protists_ichthyosporea1_collection":
-    #    species_id = "1"
-    #else:
-    #    species_id = "1"
 
     core_dict = {}
     if (args.production_name):
@@ -273,7 +262,7 @@ if __name__ == "__main__":
     )
     for meta_pair in core_meta:
         core_dict[meta_pair[0]] = meta_pair[1]
-    print(core_dict)
+
         
     # get the assembly metadata from the sources of truth (sources of truth in parentheses)
     # expected assembly meta_keys: assembly.accession (from core), assembly.date (from ena), assembly.is_reference (static), assembly.name (ena), assembly.provider_name (core or default), assembly.provider_url (core or default), assembly.level (ena), assembly.tolid (biosample), assembly.ucsc_alias (ncbi), assembly.long_name, assembly.url_name (static)


### PR DESCRIPTION
I've added a flag to input "production_name", when provided the script will get the "species_id" from the meta table, this means that the script can be used for collections databases. If this input is not provided the script works as before. 

I've also updated the IF statements checking for required keys: genebuild.annotation_source, genebuild.provider_url, genebuild.provider_name to account for the fact that a submitter may have added these manually and if they exist, I don;t want to overwrite them with info from outdated meta keys.

@ens-ftricomi the statistics pipeline would need an update to work for collections, i.e. accept core db name + production name in the csv (I suspect), and use of the correct species_id here https://github.com/Ensembl/ensembl-genes-nf/blob/4bce0582ff9efb418b4462ecec71323cb76fa556/pipelines/nextflow/modules/utils.nf#L45, but this does not break the functionality of the statistics pipeline for single cores as it stands