### PR TITLE
enforce integer parsing for thresholds

### DIFF
--- a/src/python/ensembl/genes/metrics/check_busco_score.py
+++ b/src/python/ensembl/genes/metrics/check_busco_score.py
@@ -106,9 +106,9 @@ def main():
     parser = argparse.ArgumentParser(description="Evaluate BUSCO scores from genome and protein JSON files.")
     parser.add_argument("--genome", required=True, help="Path to genome BUSCO JSON file")
     parser.add_argument("--protein", required=True, help="Path to protein BUSCO JSON file")
-    parser.add_argument("--min_range_protein_score", required=False, default=50,  help="Lowest threshold to analyse busco score in protein mode")
-    parser.add_argument("--max_range_protein_score", required=False, default=70, help="Highest threshold to analyse busco score in protein mode")
-    parser.add_argument("--diff_prot_gen_mode", required=False, default=10, help="Max difference between Busco in protein and in genome mode")
+    parser.add_argument("--min_range_protein_score",type=int, required=False, default=50,  help="Lowest threshold to analyse busco score in protein mode")
+    parser.add_argument("--max_range_protein_score", type=int, required=False, default=70, help="Highest threshold to analyse busco score in protein mode")
+    parser.add_argument("--diff_prot_gen_mode", type=int, required=False, default=10, help="Max difference between Busco in protein and in genome mode")
     args = parser.parse_args()
 
     try: # pylint: disable=broad-except


### PR DESCRIPTION
Enforce int types for thresholds in argparse

Previously, argparse defaulted to strings, leading to runtime TypeErrors
when comparing float BUSCO scores to threshold values. Adding `type=int`
for --min_range_protein_score, --max_range_protein_score,
and --diff_prot_gen_mode ensures proper numeric comparisons.


This fix was tested in this pipeline: http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-genebuild-prod-4&port=4530&dbname=vianey_test_new_anno_pipe_114&passwd=xxxxx#