### PR TITLE
Dev/metadata patching

### DIFF
--- a/src/python/ensembl/genes/metadata/README.md
+++ b/src/python/ensembl/genes/metadata/README.md
@@ -58,7 +58,7 @@ export TAXONOMY_URI="mysql+pymysql://user:pass@host:port/ncbi_taxonomy"
 python beta_patcher.py patches.csv --jira-ticket EBD-1111 --output-dir ./patches/
 
 # With team filter (only applies patches where all affected genomes belong to specified team)
-python beta_patcher.py patches.csv --jira-ticket EBD-1111 --team-filter genebuild
+python beta_patcher.py patches.csv --jira-ticket EBD-1111 --team-filter Genebuild
 ```
 
 ### Finding genome_uuid for organism/assembly patches

--- a/src/python/ensembl/genes/metadata/README.md
+++ b/src/python/ensembl/genes/metadata/README.md
@@ -54,5 +54,76 @@ export TAXONOMY_URI="mysql+pymysql://user:pass@host:port/ncbi_taxonomy"
 
 **Usage:**
 ```bash
+# Basic usage
 python beta_patcher.py patches.csv --jira-ticket EBD-1111 --output-dir ./patches/
+
+# With team filter (only applies patches where all affected genomes belong to specified team)
+python beta_patcher.py patches.csv --jira-ticket EBD-1111 --team-filter genebuild
 ```
+
+### Finding genome_uuid for organism/assembly patches
+
+When patching `organism` or `assembly` tables, you need to provide a genome_uuid. Use these queries to find genome UUIDs:
+
+**Find all genomes for a specific assembly (by accession):**
+```sql
+SELECT DISTINCT
+    genome.genome_uuid,
+    genome.production_name,
+    assembly.accession,
+    assembly.name AS assembly_name,
+    (SELECT da.value
+     FROM genome_dataset gd
+     JOIN dataset d ON gd.dataset_id = d.dataset_id AND d.name = 'genebuild'
+     JOIN dataset_attribute da ON d.dataset_id = da.dataset_id
+     JOIN attribute a ON da.attribute_id = a.attribute_id AND a.name = 'genebuild.team_responsible'
+     WHERE gd.genome_id = genome.genome_id
+     LIMIT 1) AS team_responsible
+FROM genome
+JOIN assembly ON genome.assembly_id = assembly.assembly_id
+WHERE assembly.accession = 'GCA_000001405.14'
+ORDER BY team_responsible, genome.production_name;
+```
+
+**Find all genomes for a specific organism (by biosample_id):**
+```sql
+SELECT DISTINCT
+    genome.genome_uuid,
+    genome.production_name,
+    organism.biosample_id,
+    organism.scientific_name,
+    organism.strain,
+    (SELECT da.value
+     FROM genome_dataset gd
+     JOIN dataset d ON gd.dataset_id = d.dataset_id AND d.name = 'genebuild'
+     JOIN dataset_attribute da ON d.dataset_id = da.dataset_id
+     JOIN attribute a ON da.attribute_id = a.attribute_id AND a.name = 'genebuild.team_responsible'
+     WHERE gd.genome_id = genome.genome_id
+     LIMIT 1) AS team_responsible
+FROM genome
+JOIN organism ON genome.organism_id = organism.organism_id
+WHERE organism.biosample_id = 'SAMN04851098'
+ORDER BY team_responsible, genome.production_name;
+```
+
+**Find genomes by organism strain:**
+```sql
+SELECT DISTINCT
+    genome.genome_uuid,
+    genome.production_name,
+    organism.scientific_name,
+    organism.strain,
+    (SELECT da.value
+     FROM genome_dataset gd
+     JOIN dataset d ON gd.dataset_id = d.dataset_id AND d.name = 'genebuild'
+     JOIN dataset_attribute da ON d.dataset_id = da.dataset_id
+     JOIN attribute a ON da.attribute_id = a.attribute_id AND a.name = 'genebuild.team_responsible'
+     WHERE gd.genome_id = genome.genome_id
+     LIMIT 1) AS team_responsible
+FROM genome
+JOIN organism ON genome.organism_id = organism.organism_id
+WHERE organism.scientific_name = 'Homo sapiens'
+ORDER BY team_responsible, genome.production_name;
+```
+
+Pick any one of the returned genome_uuid values to use in your CSV. The script will automatically detect and warn about all other genomes sharing that organism/assembly.

--- a/src/python/ensembl/genes/metadata/beta_patcher.py
+++ b/src/python/ensembl/genes/metadata/beta_patcher.py
@@ -313,7 +313,9 @@ def write_core_patch_for_genome(
         # Write validation SQL
         validate_file.write(f"-- {database} | {meta_key}\n")
         validate_file.write(f"USE {database};\n")
-        validate_file.write(f"SELECT '{meta_key}' AS meta_key, meta_value AS current_value, ")
+        validate_file.write(f"SELECT '{database}' AS database_name, ")
+        validate_file.write(f"'{meta_key}' AS meta_key, ")
+        validate_file.write("meta_value AS current_value, ")
         validate_file.write(f"'{escaped_value}' AS proposed_value\n")
         validate_file.write("FROM meta\n")
         validate_file.write(_core_db_where(meta_key, species_id))

--- a/src/python/ensembl/genes/metadata/beta_patcher.py
+++ b/src/python/ensembl/genes/metadata/beta_patcher.py
@@ -9,6 +9,8 @@ Generates standardized SQL patch files for fixing metadata issues in:
 This ensures metadata consistency between both databases and provides
 a standardized workflow for creating and applying patches.
 
+Requires genome_uuid for all patches.
+
 Usage:
     python beta_patcher.py patches.csv --jira-ticket EBD-1111 --output-dir ./patches/
     python beta_patcher.py patches.csv --jira-ticket EBD-1111 --core-suffix _core_115_1
@@ -126,64 +128,103 @@ def get_genome_by_uuid(genome_uuid: str) -> Optional[Dict]:
         return None
 
 
-def get_genome_by_production_name(production_name: str) -> Optional[Dict]:
+def get_team_responsible_for_genome(genome_uuid: str, dataset_type: str = "genebuild") -> Optional[str]:
     """
-    Fetch genome UUID by production name.
+    Fetch genebuild.team_responsible attribute for a genome.
 
     Args:
-        production_name: Species production name (e.g., homo_sapiens)
+        genome_uuid: Genome UUID to query
+        dataset_type: Dataset type (default: genebuild)
 
     Returns:
-        Dict containing genome information or None if not found
+        Team responsible string or None if not found
     """
     adaptor = get_genome_adaptor()
     if not adaptor:
         return None
 
     try:
-        results = adaptor.fetch_genomes(production_name=production_name)
-        if results:
-            genome, organism, assembly, release, _site = results[0]
-            return {
-                "genome_uuid": genome.genome_uuid,
-                "production_name": genome.production_name,
-                "assembly_accession": assembly.accession
-            }
+        # Use the metadata API to fetch the attribute value
+        # This queries: dataset_attribute JOIN attribute JOIN dataset JOIN genome_dataset JOIN genome
+        from sqlalchemy import text
+
+        query = text("""
+            SELECT dataset_attribute.value
+            FROM dataset_attribute
+            JOIN attribute ON dataset_attribute.attribute_id = attribute.attribute_id
+            JOIN dataset ON dataset_attribute.dataset_id = dataset.dataset_id
+            JOIN genome_dataset ON dataset.dataset_id = genome_dataset.dataset_id
+            JOIN genome ON genome_dataset.genome_id = genome.genome_id
+            WHERE genome.genome_uuid = :genome_uuid
+            AND dataset.name = :dataset_type
+            AND attribute.name = 'genebuild.team_responsible'
+        """)
+
+        with adaptor.metadata_db.connect() as conn:
+            result = conn.execute(query, {"genome_uuid": genome_uuid, "dataset_type": dataset_type})
+            row = result.fetchone()
+            if row:
+                return row[0]
         return None
     except Exception as e:
-        logging.error(f"Failed to fetch genome by production name {production_name}: {e}")
+        logging.warning(f"Failed to fetch team_responsible for genome {genome_uuid}: {e}")
         return None
 
 
-def suggest_genomes_by_production_name(production_name: str) -> List[Dict]:
+def get_affected_genomes_and_teams(genome_uuid: str, table_location: str, dataset_type: str = "genebuild") -> List[Dict]:
     """
-    Suggest genome UUIDs based on production name.
+    Get all genomes that share the same organism or assembly, and their team_responsible values.
 
     Args:
-        production_name: Species production name (e.g., homo_sapiens)
+        genome_uuid: Source genome UUID
+        table_location: Table being modified (organism or assembly)
+        dataset_type: Dataset type (default: genebuild)
 
     Returns:
-        List of matching genomes with their UUIDs
+        List of dicts with genome_uuid, production_name, and team_responsible
     """
+    if table_location not in ['organism', 'assembly']:
+        return []
+
     adaptor = get_genome_adaptor()
     if not adaptor:
         return []
 
     try:
-        results = adaptor.fetch_genomes(production_name=production_name)
-        genomes = []
-        for genome, organism, assembly, release, _site in results:
-            genomes.append({
-                "genome_uuid": genome.genome_uuid,
-                "production_name": genome.production_name,
-                "assembly_accession": assembly.accession,
-                "assembly_name": assembly.name,
-                "genebuild_version": genome.genebuild_version,
-                "release_version": release.version if release else None
-            })
-        return genomes
+        from sqlalchemy import text
+
+        if table_location == 'organism':
+            # Find all genomes sharing the same organism
+            query = text("""
+                SELECT g2.genome_uuid, g2.production_name
+                FROM genome g1
+                JOIN genome g2 ON g1.organism_id = g2.organism_id
+                WHERE g1.genome_uuid = :genome_uuid
+            """)
+        else:  # assembly
+            # Find all genomes sharing the same assembly
+            query = text("""
+                SELECT g2.genome_uuid, g2.production_name
+                FROM genome g1
+                JOIN genome g2 ON g1.assembly_id = g2.assembly_id
+                WHERE g1.genome_uuid = :genome_uuid
+            """)
+
+        affected_genomes = []
+        with adaptor.metadata_db.connect() as conn:
+            result = conn.execute(query, {"genome_uuid": genome_uuid})
+            for row in result:
+                uuid, prod_name = row
+                team = get_team_responsible_for_genome(uuid, dataset_type)
+                affected_genomes.append({
+                    "genome_uuid": uuid,
+                    "production_name": prod_name,
+                    "team_responsible": team or "UNKNOWN"
+                })
+
+        return affected_genomes
     except Exception as e:
-        logging.error(f"Failed to fetch genomes by production name {production_name}: {e}")
+        logging.warning(f"Failed to fetch affected genomes for {genome_uuid}: {e}")
         return []
 
 
@@ -213,7 +254,9 @@ def write_metadata_patch_for_genome(
     patch_file,
     genome_uuid: str,
     patches: List[Tuple[str, str, str]],
-    dataset_type: str = "genebuild"
+    dataset_type: str = "genebuild",
+    logger: logging.Logger = None,
+    team_filter: str = None
 ):
     """
     Write validation and patch SQL for a single genome to open file handles.
@@ -224,9 +267,84 @@ def write_metadata_patch_for_genome(
         genome_uuid: Genome UUID
         patches: List of (attribute_name, new_value, table_location) tuples
         dataset_type: Dataset type (genebuild, assembly, etc.)
+        logger: Logger instance for warnings
+        team_filter: Optional team name to filter by (e.g., 'genebuild')
     """
+    # Valid table locations
+    VALID_TABLES = {'dataset_attribute', 'genome', 'organism', 'assembly'}
+
     for attribute_name, new_value, table_location in patches:
         escaped_value = new_value.replace("'", "''")
+
+        # Validate table_location
+        if table_location not in VALID_TABLES:
+            validate_file.write(f"-- ERROR: Invalid table_location '{table_location}' for {attribute_name}\n")
+            validate_file.write(f"-- Valid tables: {', '.join(VALID_TABLES)}\n\n")
+            patch_file.write(f"-- ERROR: Invalid table_location '{table_location}' for {attribute_name}\n")
+            patch_file.write(f"-- Valid tables: {', '.join(VALID_TABLES)}\n\n")
+            continue
+
+        # Check for organism/assembly modifications and warn about affected genomes
+        if table_location in ['organism', 'assembly']:
+            affected_genomes = get_affected_genomes_and_teams(genome_uuid, table_location, dataset_type)
+            if affected_genomes and len(affected_genomes) > 0:
+                # Group by team_responsible
+                teams_map = {}
+                for genome_data in affected_genomes:
+                    team = genome_data['team_responsible']
+                    if team not in teams_map:
+                        teams_map[team] = []
+                    teams_map[team].append(f"{genome_data['production_name']} ({genome_data['genome_uuid']})")
+
+                # Check team filter - skip if not all genomes match the filter
+                if team_filter:
+                    teams_set = set(teams_map.keys())
+                    if teams_set != {team_filter}:
+                        skip_msg = f"-- SKIPPED: {table_location} modification affects teams {teams_set}, filter requires only '{team_filter}'\n"
+                        validate_file.write(skip_msg)
+                        patch_file.write(skip_msg)
+                        for team, genomes in teams_map.items():
+                            team_line = f"--   Team: {team}\n"
+                            validate_file.write(team_line)
+                            patch_file.write(team_line)
+                            for genome_str in genomes:
+                                genome_line = f"--     - {genome_str}\n"
+                                validate_file.write(genome_line)
+                                patch_file.write(genome_line)
+                        validate_file.write("\n")
+                        patch_file.write("\n")
+                        if logger:
+                            logger.warning(f"SKIPPED: {attribute_name} for {genome_uuid} - affects teams {teams_set}, filter requires '{team_filter}'")
+                        continue
+
+                # Write warning to both files
+                warning_header = f"-- WARNING: Modifying shared {table_location} affects {len(affected_genomes)} genome(s)\n"
+                validate_file.write(warning_header)
+                patch_file.write(warning_header)
+
+                for team, genomes in teams_map.items():
+                    team_line = f"--   Team: {team}\n"
+                    validate_file.write(team_line)
+                    patch_file.write(team_line)
+                    for genome_str in genomes:
+                        genome_line = f"--     - {genome_str}\n"
+                        validate_file.write(genome_line)
+                        patch_file.write(genome_line)
+
+                if team_filter:
+                    validate_file.write(f"-- Team filter '{team_filter}' PASSED - all affected genomes owned by this team\n")
+                    patch_file.write(f"-- Team filter '{team_filter}' PASSED - all affected genomes owned by this team\n")
+                else:
+                    validate_file.write("-- ENSURE CONSULTATION WITH ALL AFFECTED TEAMS BEFORE APPLYING\n")
+                    patch_file.write("-- ENSURE CONSULTATION WITH ALL AFFECTED TEAMS BEFORE APPLYING\n")
+
+                # Log warning to CLI
+                if logger:
+                    logger.warning(f"Modifying {table_location} for {genome_uuid} affects {len(affected_genomes)} genome(s)")
+                    for team, genomes in teams_map.items():
+                        logger.warning(f"  Team {team}: {len(genomes)} genome(s)")
+                    if team_filter:
+                        logger.info(f"Team filter '{team_filter}' passed for {attribute_name}")
 
         # Write validation SQL
         validate_file.write(f"-- {genome_uuid} | {attribute_name} (table: {table_location})\n")
@@ -244,9 +362,20 @@ def write_metadata_patch_for_genome(
             validate_file.write(f"'{escaped_value}' AS proposed_value\n")
             validate_file.write("FROM genome\n")
             validate_file.write(f"WHERE genome.genome_uuid = '{genome_uuid}';\n\n")
-        else:
-            validate_file.write(f"-- WARNING: Unknown table_location '{table_location}'\n")
-            validate_file.write(f"-- Manual validation required for {attribute_name}\n\n")
+        elif table_location == 'organism':
+            column_name = attribute_name.split('.')[-1]
+            validate_file.write(f"SELECT genome.genome_uuid, organism.{column_name} AS current_value, ")
+            validate_file.write(f"'{escaped_value}' AS proposed_value\n")
+            validate_file.write("FROM organism\n")
+            validate_file.write("JOIN genome ON organism.organism_id = genome.organism_id\n")
+            validate_file.write(f"WHERE genome.genome_uuid = '{genome_uuid}';\n\n")
+        elif table_location == 'assembly':
+            column_name = attribute_name.split('.')[-1]
+            validate_file.write(f"SELECT genome.genome_uuid, assembly.{column_name} AS current_value, ")
+            validate_file.write(f"'{escaped_value}' AS proposed_value\n")
+            validate_file.write("FROM assembly\n")
+            validate_file.write("JOIN genome ON assembly.assembly_id = genome.assembly_id\n")
+            validate_file.write(f"WHERE genome.genome_uuid = '{genome_uuid}';\n\n")
 
         # Write patch SQL
         patch_file.write(f"-- {genome_uuid} | {attribute_name} (table: {table_location})\n")
@@ -277,9 +406,19 @@ def write_metadata_patch_for_genome(
             patch_file.write(f"SET {column_name} = '{escaped_value}'\n")
             patch_file.write(f"WHERE genome_uuid = '{genome_uuid}';\n\n")
 
-        else:
-            patch_file.write(f"-- ERROR: Unknown table_location '{table_location}'\n")
-            patch_file.write(f"-- Manual SQL required for {attribute_name}\n\n")
+        elif table_location == 'organism':
+            column_name = attribute_name.split('.')[-1]
+            patch_file.write("UPDATE organism\n")
+            patch_file.write("JOIN genome ON organism.organism_id = genome.organism_id\n")
+            patch_file.write(f"SET organism.{column_name} = '{escaped_value}'\n")
+            patch_file.write(f"WHERE genome.genome_uuid = '{genome_uuid}';\n\n")
+
+        elif table_location == 'assembly':
+            column_name = attribute_name.split('.')[-1]
+            patch_file.write("UPDATE assembly\n")
+            patch_file.write("JOIN genome ON assembly.assembly_id = genome.assembly_id\n")
+            patch_file.write(f"SET assembly.{column_name} = '{escaped_value}'\n")
+            patch_file.write(f"WHERE genome.genome_uuid = '{genome_uuid}';\n\n")
 
 
 def _core_db_where(meta_key: str, species_id: int) -> str:
@@ -337,12 +476,13 @@ def read_csv_patches(csv_file: Path, core_suffix: str = "_core_114_1") -> List[D
     Read patches from CSV file.
 
     CSV columns:
-    - production_name OR genome_uuid (one required)
+    - genome_uuid (required)
     - meta_key (required)
     - desired_meta_value (required)
     - dataset_type (optional, default: genebuild)
     - species_id (optional, default: 1)
     - table_location (optional, default: dataset_attribute)
+      Valid values: dataset_attribute, genome, organism, assembly
 
     Args:
         csv_file: Path to CSV file
@@ -360,29 +500,23 @@ def read_csv_patches(csv_file: Path, core_suffix: str = "_core_114_1") -> List[D
         reader = csv.DictReader(f)
 
         # Validate required columns
-        required_cols = {'meta_key', 'desired_meta_value'}
-        identifier_cols = {'production_name', 'genome_uuid'}
+        required_cols = {'genome_uuid', 'meta_key', 'desired_meta_value'}
 
         if not required_cols.issubset(reader.fieldnames):
             raise ValueError(f"CSV must contain columns: {required_cols}")
 
-        if not identifier_cols.intersection(reader.fieldnames):
-            raise ValueError(f"CSV must contain at least one of: {identifier_cols}")
-
         for row_num, row in enumerate(reader, start=2):  # Start at 2 for header + 1-indexed
-            # Check we have at least one identifier
-            if not row.get('production_name') and not row.get('genome_uuid'):
-                logging.error(f"Row {row_num}: Must provide either production_name or genome_uuid")
+            # Check required fields
+            if not row.get('genome_uuid'):
+                logging.error(f"Row {row_num}: Missing required field genome_uuid")
                 continue
 
-            # Check required fields
             if not row.get('meta_key') or not row.get('desired_meta_value'):
                 logging.error(f"Row {row_num}: Missing required fields meta_key or desired_meta_value")
                 continue
 
             patch = {
-                'production_name': row.get('production_name', '').strip(),
-                'genome_uuid': row.get('genome_uuid', '').strip(),
+                'genome_uuid': row['genome_uuid'].strip(),
                 'meta_key': row['meta_key'].strip(),
                 'desired_meta_value': row['desired_meta_value'].strip(),
                 'dataset_type': row.get('dataset_type', 'genebuild').strip(),
@@ -399,7 +533,7 @@ def read_csv_patches(csv_file: Path, core_suffix: str = "_core_114_1") -> List[D
 
 def resolve_genome_info(patch: Dict, logger: logging.Logger) -> Optional[Dict]:
     """
-    Resolve genome UUID and production name from patch data.
+    Resolve production name from genome UUID.
 
     Args:
         patch: Patch dictionary from CSV
@@ -410,38 +544,16 @@ def resolve_genome_info(patch: Dict, logger: logging.Logger) -> Optional[Dict]:
     """
     row_num = patch['row_num']
     genome_uuid = patch['genome_uuid']
-    production_name = patch['production_name']
 
-    # If production_name provided, resolve to genome_uuid
-    if production_name and not genome_uuid:
-        logger.info(f"Row {row_num}: Resolving genome_uuid from production_name: {production_name}")
-        genomes = suggest_genomes_by_production_name(production_name)
+    logger.info(f"Row {row_num}: Fetching production_name for genome_uuid: {genome_uuid}")
+    genome_info = get_genome_by_uuid(genome_uuid)
 
-        if not genomes:
-            logger.error(f"Row {row_num}: No genomes found for production_name: {production_name}")
-            return None
+    if not genome_info:
+        logger.error(f"Row {row_num}: Could not fetch genome information for UUID: {genome_uuid}")
+        return None
 
-        if len(genomes) > 1:
-            logger.error(
-                f"Row {row_num}: Ambiguous production_name '{production_name}' matches {len(genomes)} genomes. "
-                f"Please specify genome_uuid instead. Found UUIDs: {[g['genome_uuid'] for g in genomes]}"
-            )
-            return None
-
-        genome_uuid = genomes[0]['genome_uuid']
-        logger.info(f"Row {row_num}: Resolved to genome_uuid: {genome_uuid}")
-
-    # If genome_uuid provided, get production_name if not already set
-    if genome_uuid and not production_name:
-        logger.info(f"Row {row_num}: Fetching production_name for genome_uuid: {genome_uuid}")
-        genome_info = get_genome_by_uuid(genome_uuid)
-
-        if not genome_info:
-            logger.error(f"Row {row_num}: Could not fetch genome information for UUID: {genome_uuid}")
-            return None
-
-        production_name = genome_info['production_name']
-        logger.info(f"Row {row_num}: Found production_name: {production_name}")
+    production_name = genome_info['production_name']
+    logger.info(f"Row {row_num}: Found production_name: {production_name}")
 
     # Build core database name
     core_db_name = f"{production_name}{patch['core_suffix']}"
@@ -501,7 +613,8 @@ def generate_all_patches(
     grouped_patches: Dict[str, Dict],
     output_dir: Path,
     jira_ticket: str,
-    logger: logging.Logger
+    logger: logging.Logger,
+    team_filter: str = None
 ) -> bool:
     """
     Generate consolidated patch files for all genomes.
@@ -511,6 +624,7 @@ def generate_all_patches(
         output_dir: Output directory for patch files
         jira_ticket: Jira ticket reference
         logger: Logger instance
+        team_filter: Optional team name to filter organism/assembly patches
 
     Returns:
         True if successful, False otherwise
@@ -540,7 +654,7 @@ def generate_all_patches(
                 logger.info(f"  Metadata: {production_name} ({genome_uuid}): {len(patches)} patches")
 
                 write_metadata_patch_for_genome(
-                    val_f, patch_f, genome_uuid, patches, genome_data['dataset_type']
+                    val_f, patch_f, genome_uuid, patches, genome_data['dataset_type'], logger, team_filter
                 )
 
         # Write core patches
@@ -590,14 +704,17 @@ Examples:
   # Run validate_*.sql files before applying patch_*.sql files
 
 CSV Format:
-  Required columns: meta_key, desired_meta_value
-  Identifier (one required): production_name OR genome_uuid
+  Required columns: genome_uuid, meta_key, desired_meta_value
   Optional columns: dataset_type, species_id, table_location
 
+  table_location valid values: dataset_attribute (default), genome, organism, assembly
+
   Example:
-    production_name,genome_uuid,meta_key,desired_meta_value,dataset_type,species_id,table_location
-    homo_sapiens,,assembly.name,GRCh38.p14,genebuild,1,dataset_attribute
-    ,a7335667-93e7-11ec-a39d-005056b38ce3,organism.strain,Reference,genebuild,1,genome
+    genome_uuid,meta_key,desired_meta_value,dataset_type,species_id,table_location
+    a7335667-93e7-11ec-a39d-005056b38ce3,assembly.name,GRCh38.p14,genebuild,1,dataset_attribute
+    a7335667-93e7-11ec-a39d-005056b38ce3,genebuild_version,2024-01,genebuild,1,genome
+    a7335667-93e7-11ec-a39d-005056b38ce3,strain,reference,genebuild,1,organism
+    a7335667-93e7-11ec-a39d-005056b38ce3,level,chromosome,genebuild,1,assembly
 
 See patches_template.csv for a complete example.
         """
@@ -647,6 +764,13 @@ See patches_template.csv for a complete example.
         help='Output directory for patch files (default: current directory)'
     )
 
+    # Team filter option
+    parser.add_argument(
+        '--team-filter',
+        type=str,
+        help='Only apply organism/assembly patches if all affected genomes belong to this team (e.g., "genebuild")'
+    )
+
     args = parser.parse_args()
 
     # Validate CSV file exists
@@ -689,7 +813,8 @@ See patches_template.csv for a complete example.
         return 1
 
     # Generate consolidated patch files
-    if generate_all_patches(grouped_patches, args.output_dir, args.jira_ticket, logger):
+    team_filter = getattr(args, 'team_filter', None)
+    if generate_all_patches(grouped_patches, args.output_dir, args.jira_ticket, logger, team_filter):
         logger.info(f"Success! Log: {log_file}")
         return 0
     else:

--- a/src/python/ensembl/genes/metadata/patches_template.csv
+++ b/src/python/ensembl/genes/metadata/patches_template.csv
@@ -1,5 +1,5 @@
-production_name,genome_uuid,meta_key,desired_meta_value,dataset_type,species_id,table_location
-homo_sapiens,,assembly.name,GRCh38.p14,genebuild,1,dataset_attribute
-,a7335667-93e7-11ec-a39d-005056b38ce3,organism.strain,Reference,genebuild,1,genome
-mus_musculus,,genebuild.version,ENS02,genebuild,1,dataset_attribute
-danio_rerio,,assembly.provider_name,Ensembl,genebuild,1,dataset_attribute
+genome_uuid,meta_key,desired_meta_value,dataset_type,species_id,table_location
+a7335667-93e7-11ec-a39d-005056b38ce3,assembly.name,GRCh38.p14,genebuild,1,dataset_attribute
+a7335667-93e7-11ec-a39d-005056b38ce3,genebuild_version,2024-01,genebuild,1,genome
+b8446778-a4f8-22fd-b4ae-116167c49df4,strain,reference,genebuild,1,organism
+d0668990-c6h0-44hf-d6cg-338389e6bfh6,genebuild.annotation_source,ensembl,genebuild,1,dataset_attribute


### PR DESCRIPTION
Improve validation query readability by reporting core name in SELECT 

Enable generation of patches of metadata in `assembly` and `organism` tables. 

Adopt use of `genebuild.team_responsible` to ensure patches don't clash with other teams specified metadata. 