### PR TITLE
refactor to have main

### DIFF
--- a/src/python/ensembl/genes/metadata/core_meta_data.py
+++ b/src/python/ensembl/genes/metadata/core_meta_data.py
@@ -324,6 +324,7 @@ def write_metadata_json(  # pylint: disable=too-many-arguments
         json_out.write("\n")
 
 
+# pylint: disable=too-many-locals,too-many-branches,too-many-statements
 def main() -> None:
     parser = argparse.ArgumentParser(description="Prepare SQL updates for core dbs")
     parser.add_argument(

--- a/src/python/ensembl/genes/metadata/core_meta_data.py
+++ b/src/python/ensembl/genes/metadata/core_meta_data.py
@@ -324,7 +324,7 @@ def write_metadata_json(  # pylint: disable=too-many-arguments
         json_out.write("\n")
 
 
-if __name__ == "__main__":
+def main() -> None:
     parser = argparse.ArgumentParser(description="Prepare SQL updates for core dbs")
     parser.add_argument(
         "-o",
@@ -912,3 +912,7 @@ if __name__ == "__main__":
                 for key, val in truth_dict.items()
             )
         )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In order to call core_meta_data from the pyproject.toml we need to actually have a 'main' 
